### PR TITLE
WebView enter text in input field with events firing

### DIFF
--- a/instrumentation_backend/src/sh/calaba/instrumentationbackend/actions/webview/PressByCssSelector.java
+++ b/instrumentation_backend/src/sh/calaba/instrumentationbackend/actions/webview/PressByCssSelector.java
@@ -1,6 +1,7 @@
 package sh.calaba.instrumentationbackend.actions.webview;
 
 
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.TestHelpers;
 import sh.calaba.instrumentationbackend.actions.Action;
@@ -10,20 +11,27 @@ import android.webkit.WebView;
 public class PressByCssSelector implements Action {
 
     @Override
-    public Result execute(String... args) {
+    public Result execute(final String... args) {
     	for (CalabashChromeClient ccc : CalabashChromeClient.findAndPrepareWebViews()) {
-    		WebView webView = ccc.getWebView();
-			
-			webView.loadUrl("javascript:(function() {" +
-				"var element = document.querySelector(\"" + args[0] + "\");" +
-				"if (element != null) {" +
-				"	var oEvent = document.createEvent ('MouseEvent');" + 
-				"	oEvent.initMouseEvent('click', true, true,window, 1, 1, 1, 1, 1, false, false, false, false, 0, element);" +
-				"	element.dispatchEvent( oEvent );" +
-				"	prompt('calabash:true');" +
-				"}" +
-				"prompt('calabash:false');" + 
-				"})()");
+    		final WebView webView = ccc.getWebView();
+
+            // runOnUiThread to avoid spurious "Only the original thread that created a view hierarchy can touch its views." errors
+            InstrumentationBackend.solo.getCurrentActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    webView.loadUrl("javascript:(function() {" +
+                            "var element = document.querySelector(\"" + args[0] + "\");" +
+                            "if (element != null) {" +
+                            "	var oEvent = document.createEvent ('MouseEvent');" +
+                            "	oEvent.initMouseEvent('click', true, true,window, 1, 1, 1, 1, 1, false, false, false, false, 0, element);" +
+                            "	element.dispatchEvent( oEvent );" +
+                            "	prompt('calabash:true');" +
+                            "}" +
+                            "prompt('calabash:false');" +
+                            "})()");
+                }
+            });
+
 
 			String r = ccc.getResult();
 			System.out.println("clickOnSelector: " + r);

--- a/instrumentation_backend/src/sh/calaba/instrumentationbackend/actions/webview/SetPropertyByCssSelector.java
+++ b/instrumentation_backend/src/sh/calaba/instrumentationbackend/actions/webview/SetPropertyByCssSelector.java
@@ -1,6 +1,7 @@
 package sh.calaba.instrumentationbackend.actions.webview;
 
 
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.TestHelpers;
 import sh.calaba.instrumentationbackend.actions.Action;
@@ -9,21 +10,96 @@ import android.webkit.WebView;
 
 public class SetPropertyByCssSelector implements Action {
 
+    // todo: this probably needs to be done in a nicer way :)
+    static boolean awesomeStuffAlreadyInjected = false;
+
     @Override
     public Result execute(String... args) {
     	String cssSelector = args[0];
     	String propertyName = args[1];
     	String value = args[2];
-    	                         
+
+
     	for (CalabashChromeClient ccc : CalabashChromeClient.findAndPrepareWebViews()) {
-    		WebView webView = ccc.getWebView();
+    		final WebView webView = ccc.getWebView();
 			
-    		String assignment = "document.querySelector(\"" + cssSelector + "\")." + propertyName + " = " + value + ";";
-    		System.out.println(assignment);
-			webView.loadUrl("javascript:(function() {" +
-				assignment +
-				"prompt('calabash:true');" + 
-				"})()");
+    		String functions = "";
+
+            if (!awesomeStuffAlreadyInjected) {
+                awesomeStuffAlreadyInjected = true;
+                System.out.println("awesomeStuffAlreadyInjected*****************************");
+                functions = "        function simulateKeyEvent(elem, character) {\n" +
+                "            var ch = character.charCodeAt(0);\n" +
+                "\n" +
+                "            var evt;\n" +
+                        "\n" +
+                "            evt = document.createEvent('KeyboardEvent');\n" +
+                "            evt.initKeyboardEvent('keydown', true, true, window, 0, 0, 0, 0, 0, ch);\n" +
+                "            elem.dispatchEvent(evt);\n" +
+                "\n" +
+                "            evt = document.createEvent('KeyboardEvent');\n" +
+                "            evt.initKeyboardEvent('keyup', true, true, window, 0, 0, 0, 0, 0, ch);\n" +
+                "            elem.dispatchEvent(evt);\n" +
+                "\n" +
+                "            evt = document.createEvent('KeyboardEvent');\n" +
+                "            evt.initKeyboardEvent('keypress', true, true, window, 0, 0, 0, 0, 0, ch);\n" +
+                "            elem.dispatchEvent(evt);\n" +
+                "        }\n" +
+                "";
+
+                functions +=
+                        "        function enterTextIntoInputField(elem, text) {\n" +
+                        "            for (var i = 0; i < text.length; i++) {\n" +
+                        "                var ch = text.charAt(i);\n" +
+                        "                elem.value += ch;\n" +
+                        "                simulateKeyEvent(elem, ch);\n" +
+                        "            }\n" +
+                        "        }\n" +
+                        "";
+
+                functions +=
+                        "        function fireHTMLEvent(elem, eventName) {\n" +
+                        "            var evt = document.createEvent(\"HTMLEvents\");\n" +
+                        "            evt.initEvent(eventName, true, true );\n" +
+                        "            return !elem.dispatchEvent(evt);\n" +
+                        "        }\n" +
+                        "";
+
+                functions +=
+                        "        function selectInputField(elem) {\n" +
+                        "            elem.click();\n" +
+                        "            elem.focus();\n" +
+                        "        }\n" +
+                        "";
+
+                functions +=
+                        "        function deselectInputField(elem) {\n" +
+                                "            fireHTMLEvent(elem, 'change');\n" +
+                                "            fireHTMLEvent(elem, 'blur');\n" +
+                                "        }\n" +
+                                "";
+            }
+
+            final String assignments = "var elem = document.getElementById('" + cssSelector + "'); selectInputField(elem); enterTextIntoInputField(elem, '" + value + "'); deselectInputField(elem); ";
+
+    		System.out.println(assignments);
+    		System.out.println(functions);
+
+            if (functions != null && functions.trim().length() > 0) {
+                webView.loadUrl("javascript:" + functions);
+            }
+
+            // runOnUiThread to avoid spurious "Only the original thread that created a view hierarchy can touch its views." errors
+            InstrumentationBackend.solo.getCurrentActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    webView.loadUrl("javascript:(function() {" +
+                            assignments +
+                            "prompt('calabash:true');" +
+                            "})()");
+                }
+            });
+
 
 			String r = ccc.getResult();
 			System.out.println("setPropertyByCssSelector: " + r);


### PR DESCRIPTION
Worked around exception "Only the original thread that created a view hierarchy can touch its views."
by letting the webview loadUrl happen on UI thread.

Added code to fire js events to mimick:
- click/tap on input field
- focus
- keydown/keyup/keypress for each character entered
- change+blur

With these changes, this is not so much a action that sets any property on an element,
but more a specific SetInputTextValue-like action. Actually, the "propertyName"
is not used anymore. Not sure how this is going to be in the final !?
