### PR TITLE
Allow device/emulator to be selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ To run your test:
 
     ant test
 
+To specify on which device the test should run (if you have both an emulator running and a device attached), pass the `adb.device.arg` system property (`-e` or `-d`) like so:
+
+    ant test -Dadb.device.arg=-e
+
 
 Predefined steps
 -----------------

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,7 @@
       Bits and pices plucked out of $ANDROID_HOME/tools/ant/build.xml
     </description>
 
+    <property name="adb.device.arg" value="" />
     <property environment="env"/>    
     <property file="build.properties"/>
     <property name="staging.dir" value="staging"/>
@@ -44,6 +45,7 @@
     <target name="test" description="Run test features" depends="install.app, install.test">
 	      <exec executable="cucumber">
           <env key="TEST_PACKAGE_NAME" value="${tested.package_name}.test" />
+          <arg line="ADB_DEVICE_ARG=${adb.device.arg}" />
           <arg line="features/playlist.feature" />
        </exec>
     </target>
@@ -121,9 +123,10 @@
       <echo message="Installing:${apk.to.install}"/>      
 
       <exec executable="${env.ANDROID_HOME}/platform-tools/adb" failonerror="true">
-	<arg value="install" />
-	<arg value="-r" />
-	<arg path="${apk.full.path}" />
+        <arg value="${adb.device.arg}" />
+        <arg value="install" />
+        <arg value="-r" />
+        <arg path="${apk.full.path}" />
       </exec>
     </target>
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -71,5 +71,5 @@ def create_port_forward_to_test_server
 end
 
 def adb_command
-  "#{ENV['ANDROID_HOME']}/platform-tools/adb"
+  "#{ENV['ANDROID_HOME']}/platform-tools/adb #{ENV["ADB_DEVICE_ARG"]}"
 end


### PR DESCRIPTION
Similar to the android SDK tools, this pull request allows you to pass a system property to ant (or cucumber) to specify whether the connected device or emulator should be used for tests.
