### PR TITLE
All log output to stderr

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -5,9 +5,8 @@ require 'socket'
 require 'timeout'
 
 
-Step_line = 0
 def performAction(action, *arguments)
-  puts "#{Time.now} - Action: #{action} - Params: #{arguments.join(', ')}"
+  $stderr.puts "#{Time.now} - Action: #{action} - Params: #{arguments.join(', ')}"
 
   action = {"command" => action, "arguments" => arguments}
 
@@ -16,10 +15,10 @@ def performAction(action, *arguments)
       @@client.send(action.to_json + "\n", 0) #force_encoding('UTF-8') seems to be missing from JRuby
       result = @@client.readline
     rescue Exception => e
-      puts "#{Time.now} - error communicating with test server: #{e}"
+      $stderr.puts "#{Time.now} - error communicating with test server: #{e}"
       raise e
     end
-    puts "#{Time.now} - Result:'" + result + "'"
+    $stderr.puts "#{Time.now} - Result:'" + result + "'"
     raise "Empty result from TestServer" if result.chomp.empty?
     result = JSON.parse(result)
     raise result["message"].to_s unless result["success"]
@@ -31,13 +30,13 @@ end
 
 Before do |scenario|
 
-  system("#{adb_command} shell am instrument -w -e class sh.calaba.instrumentationbackend.InstrumentationBackend #{ENV['TEST_PACKAGE_NAME']}/android.test.InstrumentationTestRunner &")
+  system("#{adb_command} shell am instrument -w -e class sh.calaba.instrumentationbackend.InstrumentationBackend #{ENV['TEST_PACKAGE_NAME']}/android.test.InstrumentationTestRunner 1>&2 &")
   sleep 2
   begin
     establish_connection_to_test_server
-    puts "#{Time.now} - Connection established"
+    $stderr.puts "#{Time.now} - Connection established"
   rescue Exception => e
-    puts "#{Time.now} - Exception:#{e.backtrace}"
+    $stderr.puts "#{Time.now} - Exception:#{e.backtrace}"
   end
 end
 
@@ -52,22 +51,22 @@ def establish_connection_to_test_server
     Timeout.timeout(5) do
       @@client = TCPSocket.open('127.0.0.1',7101)
       @@client.send("Ping!\n",0)
-      puts "#{Time.now} - Got '#" + @@client.readline + "' from testserver"
+      $stderr.puts "#{Time.now} - Got '#" + @@client.readline + "' from testserver"
     end
   rescue Exception => e
-    puts "#{Time.now} - Got exception:#{e}. Retrying!"
+    $stderr.puts "#{Time.now} - Got exception:#{e}. Retrying!"
     sleep(1)
     retry unless Time.now > end_time
   end
 end
 
 def close_connection_to_test_server
-  $stdout.puts "#{Time.now} - Closing connection to test"
+  $stderr.puts "#{Time.now} - Closing connection to test"
   @@client.close
 end
 
 def create_port_forward_to_test_server
-  puts `#{adb_command} forward tcp:7101 tcp:7101`
+  $stderr.puts `#{adb_command} forward tcp:7101 tcp:7101`
 end
 
 def adb_command


### PR DESCRIPTION
This pull request sends all logging output from calabash to stderr instead of stdout. This allows the user to redirect stderr elsewhere so that only the normal cucumber output is visible.
