### PR TITLE
Fix so that ant also works when no adb.device.arg argument is given

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -129,7 +129,7 @@
       <echo message="Installing:${apk.to.install}"/>      
 
       <exec executable="${env.ANDROID_HOME}/platform-tools/adb" failonerror="true">
-        <arg value="${adb.device.arg}" />
+        <arg line="${adb.device.arg}" />
         <arg value="install" />
         <arg value="-r" />
         <arg path="${apk.full.path}" />


### PR DESCRIPTION
The adb.device.arg needs to be passed using the arg 'line' attribute so that it works when empty. Forgot to test that case.
