### PR TITLE
Added check that tested.apk exists

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -42,7 +42,7 @@
     </path>
     
     <path id="android.target.classpath">
-      <fileset dir="${env.ANDROID_HOME}/platforms/android-8/" includes="*.jar"/>
+      <fileset dir="${env.ANDROID_HOME}/platforms/android-4/" includes="*.jar"/>
     </path>
 
     <target name="test" description="Run test features" depends="package">
@@ -78,13 +78,7 @@
       </uptodate>
     </target>
     
-
-    <target name="copy_features">
-      <copy todir="features/">
-        <fileset dir="../FlyingColorsPlayerAid/features"/>
-      </copy>
-    </target>
-    <target name="stage" depends="-init, copy_features" unless="test.app.upto.date">
+    <target name="stage" depends="-init" unless="test.app.upto.date">
   
       <mkdir dir="${staging.dir}"/>
       <mkdir dir="${bin.dir}"/>


### PR DESCRIPTION
Ive added a check (called from the "init" target) that verifies that the apk defined in tested.apk property actually exists and fails the build with an appropriate error message if it doesn't.

Before this would just lead to the following unhelpful message:
/Users/erikhansen/Development/workspace/calabash-android/build.xml:127: The following error occurred while executing this line:
/Users/erikhansen/Development/workspace/calabash-android/build.xml:114: The following error occurred while executing this line:
/Users/erikhansen/Development/workspace/calabash-android/build.xml:77: The following error occurred while executing this line:
/Users/erikhansen/Development/workspace/calabash-android/build.xml:96: exec returned: 1
