### PR TITLE
Wait for arbitrary view by content description

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/progress_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/progress_steps.rb
@@ -40,6 +40,11 @@ Then /^I wait for the view with id "([^\"]*)" to appear$/ do |text|
   performAction('wait_for_view_by_id', text)
 end
 
+Then /^I wait for the "([^\"]*)" view to appear$/ do |text|
+  performAction('wait_for_view', text)
+end
+
+
 Then /^I wait for the "([^\"]*)" screen to appear$/ do |text|
     performAction('wait_for_screen', text)
 end

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/WaitForView.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/WaitForView.java
@@ -1,0 +1,43 @@
+package sh.calaba.instrumentationbackend.actions.view;
+
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
+import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.TestHelpers;
+import sh.calaba.instrumentationbackend.actions.Action;
+import android.view.View;
+
+public class WaitForView implements Action {
+
+    @Override
+    public Result execute(String... args) {
+        String text = args[0];
+        long endTime = System.currentTimeMillis() + 60000;
+        while (System.currentTimeMillis() < endTime) {
+            if (InstrumentationBackend.solo.searchButton(text) || searchForViewWithContentDescription(text)) {
+                return Result.successResult();
+            } else {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    return Result.fromThrowable(e);
+                }
+            }
+        }
+        return new Result(false, "Timed out while waiting for view with text or contentDescription:'" + text + "'");
+    }
+
+    @Override
+    public String key() {
+        return "wait_for_view";
+    }
+
+    private boolean searchForViewWithContentDescription(String description) {
+        View view = TestHelpers.getViewByDescription(description);
+        if (view != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
For some of my testing I needed to wait for an arbitrary view (an `ImageView` in my case) with a particular content description rather than id to appear. This addition allows that.
