### PR TITLE
Compile the instrumentation backend with the debug flag

### DIFF
--- a/ruby-gem/test-server/build.xml
+++ b/ruby-gem/test-server/build.xml
@@ -112,6 +112,7 @@
 	       verbose="${verbose}"
          source="1.6"
          target="1.6"
+         debug="true"
 	       bootclasspathref="android.target.classpath"
 	       classpath="${extensible.classpath}"
 	       classpathref="jar.libs.ref">


### PR DESCRIPTION
With the debug flag enabled, there's no [performance difference](http://stackoverflow.com/questions/218033), but you get complete stack traces with line numbers. This is immensely useful if the backend throws any exceptions.
