### PR TITLE
Make ObjectMapper final and initialize it at definition to prevent NPE

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/HttpServer.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/HttpServer.java
@@ -13,12 +13,10 @@ public class HttpServer extends NanoHTTPD {
 	private static final String TAG = "IntrumentationBackend";
 	private boolean running = true;
 	
-	private ObjectMapper mapper;
+	private final ObjectMapper mapper = createJsonMapper();
 
 	public HttpServer() {
 		super(7102, new File("/"));
-
-		mapper = createJsonMapper();
 	}
 
 	public Response serve( String uri, String method, Properties header, Properties params, Properties files )


### PR DESCRIPTION
For some reason when running my tests, I'm regularly (>50%) getting NullPointerExceptions because the `mapper` field is null in `HttpServer`. My only explanation for this is that `NanoHTTPD` is doing some work before the `HttpServer` gets a chance to initialize `mapper`.

My fix for this is to make mapper final and initialize it at definition. The NPE's have disappeared.
