### PR TITLE
Shut down the test server after each scenario

### DIFF
--- a/ruby-gem/features-skeleton/support/app_life_cycle_hooks.rb
+++ b/ruby-gem/features-skeleton/support/app_life_cycle_hooks.rb
@@ -5,3 +5,7 @@ Before do |scenario|
   return if scenario.failed? #No need to start the server is anything before this has failed.
   start_test_server_in_background
 end
+
+After do
+    shutdown_test_server
+end

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -29,6 +29,10 @@ module Operations
     end
   end
 
+  def shutdown_test_server
+    Device.default_device.http('/kill', {})
+  end
+
   def performAction(action, *arguments)
     Device.default_device.perform_action(action, *arguments)
   end


### PR DESCRIPTION
Instead of just uninstalling the instrumentation backend or leaving it running, this pull request adds an `After` hook which calls the `/kill` endpoint in the backend to tell it to shutdown. This makes my logcat output a little less dramatic (less crashes, etc) and easier to understand, I find.
