### PR TITLE
execute_javascript updates

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/webview/ExecuteJavascript.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/webview/ExecuteJavascript.java
@@ -13,9 +13,16 @@ public class ExecuteJavascript implements Action {
 		CalabashChromeClient ccc = CalabashChromeClient.findAndPrepareWebViews().get(0);
 		final WebView webView = ccc.getWebView();
 		final String script = "javascript:(function() {"
-				+ "var result;"
+				+ " var r;"
+				+ " try {"
+				+ "  r = (function() {"
 				+ args[0] + ";"
-				+ "prompt('calabash:'+result);" + "})()";
+				+ "  }());"
+				+ " } catch (e) {"
+				+ "  r = 'Exception: ' + e;"
+				+ " }"
+				+ " prompt('calabash:'+r);" 
+				+ "}())";
 
 		System.out.println("execute javascript: " + script);
 		
@@ -30,7 +37,12 @@ public class ExecuteJavascript implements Action {
 		String r = ccc.getResult();
 		System.out.println("javascript result: " + r);
 
-		return new Result(true, r);
+		boolean success = true;
+		if (r.startsWith("Exception:")) {
+			success = false;
+		}
+
+		return new Result(success, r);
 	}
 
 	@Override


### PR DESCRIPTION
Hi,

I updated the execute_javascript command with two changes:
1. Instead of using the "result" variable for the returning a result, you should now "return" the result instead (e.g. "return 'Hello world';").  This is consistent with how Webdriver works and cleaner than using an arbitrary variable.  This is a backward incompatible change, but hopefully no-one has yet had time to use the feature.
2. JavaScript exceptions are now caught and handled gracefully:  They will cause the step to fail with a proper error message.
