### PR TITLE
ClickOnViewById - try through Robotium the first time

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/ClickOnViewById.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/ClickOnViewById.java
@@ -32,14 +32,7 @@ public class ClickOnViewById implements Action {
 			System.out.println(xy[0]);
 			System.out.println(xy[1]);
 			
-			//InstrumentationBackend.solo.clickOnView(view);		
-			if (view.isClickable()) {
-				InstrumentationBackend.solo.getCurrentActivity().runOnUiThread(new Runnable() {
-					public void run() {
-						view.performClick();
-					}	
-				});
-			}
+			InstrumentationBackend.solo.clickOnView(view);		
 		} catch(junit.framework.AssertionFailedError e) {
 			System.out.println("solo.clickOnView failed - using fallback");
 			if (view.isClickable()) {


### PR DESCRIPTION
Reverted first attempt of `ClickOnViewById` to attempt to use `InstrumentationBackend.Solo.clickOnView`.  The `catch` block alludes to trying a different method, but the first attempt was exactly the same and had this line commented out.

I'm running into an issue on Android 3.2 where ActionBar MenuItems cannot be clicked on by id because `view.isClickable()` returns false, but removing this check (and going through the `Solo`) object works.
