### PR TITLE
Use Robotium in TestHelpers.getViewById

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/TestHelpers.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/TestHelpers.java
@@ -76,7 +76,7 @@ public class TestHelpers {
             throw new RuntimeException("getViewById: Looking for view " + resName + " which does not have an id");
         }
         int id = intID.intValue();
-        View view = InstrumentationBackend.solo.getCurrentActivity().findViewById(id);
+        View view = InstrumentationBackend.solo.getView(id);
         if (view != null) {
             if (id == view.getId()) {
                 System.out.println("Did find view " + resName + ".");


### PR DESCRIPTION
Again, ran into an issue when working with menu items on Android 3.2 by their id.  Not sure why the `TestHelpers.getViewById` method was not using `InstrumentationBackend.solo.getView(int)` but was rather using `getCurrentActivity().findViewById(int)` instead.
