### PR TITLE
introduce HasView Action on Views

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/HasView.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/view/HasView.java
@@ -1,0 +1,31 @@
+package sh.calaba.instrumentationbackend.actions.view;
+
+import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.TestHelpers;
+import sh.calaba.instrumentationbackend.actions.Action;
+import android.view.View;
+
+public class HasView implements Action {
+
+    @Override
+    public Result execute(String... args) {
+        final String idArgument = args[0];
+        final View foundView = TestHelpers.getViewById(idArgument);
+        
+        if( null == foundView ) {
+            return notFoundResult(idArgument);
+        }
+        
+        return Result.successResult();
+    }
+
+    @Override
+    public String key() {
+        return "has_view";
+    }
+
+    private Result notFoundResult(final String firstArgument) {
+        return Result.failedResult(String.format("View with id %s was not found", firstArgument));
+    }
+}
+


### PR DESCRIPTION
## Summary

Introduced a `has_view` Action for Views.
## Behavior
-  Returns `true` in the `Success` if it finds it
-  Returns `false` and indicates that it couldn't find it in the `Message`
-  If the `id` does not exist at all, it gets false and the exception stack trace thrown by `TestHelpers`
