### PR TITLE
Fix screenshot location docs to describe screenshot_embed's behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Everytime you test a new binary or use an upgraded version of calabash a new tes
 The test server is an intrumentation that will run along with your app on the device to execute the test.
 
 ### Screenshot location
-Screenshots are stored in the `results` folder by default. The location can be changed by setting the `SCREENSHOT_PATH_PREFIX` environment variable.
+Screenshots are placed in the current working directory by default. The location can be changed by setting the `SCREENSHOT_PATH` environment variable.
 
-    SCREENSHOT_PATH_PREFIX=/tmp/foo calabash-android run
+    SCREENSHOT_PATH=/tmp/foo/ calabash-android run
+
+would cause the first screenshot to appear at `/tmp/foo/screenshot_0.png`.
 
 Predefined steps
 -----------------


### PR DESCRIPTION
...(instead of take_screenshot's behaviour, which is deprecated).

As a beginner I was just caught out by stale documentation about where screenshots are placed and how to control it. A quick look at the code suggests that the described behaviour is for a deprecated `take_screenshot` method, which is no longer used by default. The `screenshot_embed` method has a different default location, and uses a different environment variable to configure it.

I've updated the README.md file to describe the current behaviour.
