### PR TITLE
Wakes up the phone before running tests

### DIFF
--- a/ruby-gem/bin/calabash-android-build.rb
+++ b/ruby-gem/bin/calabash-android-build.rb
@@ -23,8 +23,14 @@ def calabash_build(app)
         zip_file.add("AndroidManifest.xml", "customAndroidManifest.xml")  
       end
     end
+    # when there is no test_servers directory, the jarsigner command fails with no explanation
+    # so here we are trying to create the test_servers if it does not exist before
+    Dir::mkdir("test_servers") unless File.exists?("test_servers")
     cmd = "jarsigner -sigalg MD5withRSA -digestalg SHA1 -signedjar #{test_server_file_name} -storepass #{keystore["keystore_password"]} -keystore \"#{File.expand_path keystore["keystore_location"]}\" #{workspace_dir}/TestServer.apk #{keystore["keystore_alias"]}"
     unless system(cmd)
+      unless File.exists?("test_servers")
+        raise "test_servers directory does not exist"
+      end
       raise "Could not sign test server"
     end
   end

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -275,6 +275,15 @@ module Operations
     end
 
     def start_test_server_in_background
+      cmd = "#{adb_command} shell am start -a android.intent.action.MAIN -n sh.calaba.android.test/sh.calaba.instrumentationbackend.WakeUp"
+      log "Starting wake up activity using:"
+      log cmd
+      if is_windows?
+        system(%Q(start /MIN cmd /C #{cmd}))
+      else
+        `#{cmd} 1>&2 &`
+      end
+
       cmd = "#{adb_command} shell am instrument -w -e target_package #{ENV["PACKAGE_NAME"]} -e main_activity #{ENV["MAIN_ACTIVITY"]} -e class sh.calaba.instrumentationbackend.InstrumentationBackend sh.calaba.android.test/sh.calaba.instrumentationbackend.CalabashInstrumentationTestRunner"
       log "Starting test server using:"
       log cmd

--- a/ruby-gem/test-server/AndroidManifest.xml
+++ b/ruby-gem/test-server/AndroidManifest.xml
@@ -6,6 +6,15 @@
     <application android:label="instrumentation_backend">
       <uses-library android:name="android.test.runner" />
       <uses-library android:name="com.google.android.maps" android:required="false" />
+      <activity
+              android:name="sh.calaba.instrumentationbackend.WakeUp"
+              android:label="WakeUp"
+              android:exported="true"
+              android:launchMode="singleInstance"
+              android:finishOnTaskLaunch="true"
+              android:stateNotNeeded="true"
+              android:noHistory="false"
+              android:excludeFromRecents="true"/>
     </application>
     <uses-sdk android:minSdkVersion="4" />
     <instrumentation android:targetPackage="#targetPackage#" android:name="sh.calaba.instrumentationbackend.CalabashInstrumentationTestRunner" />

--- a/ruby-gem/test-server/instrumentation-backend/res/values/strings.xml
+++ b/ruby-gem/test-server/instrumentation-backend/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="hello">Hello World!</string>
+    <string name="hello">Calabash-Android!</string>
     <string name="app_name">Android-cucumber-instrumentationbackendTest</string>
 
 </resources>

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/WakeUp.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/WakeUp.java
@@ -1,0 +1,30 @@
+package sh.calaba.instrumentationbackend;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+import android.view.Window;
+import android.view.WindowManager;
+
+/**
+ * @author casidiablo
+ * @version 1.0
+ */
+public class WakeUp extends Activity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Window window = getWindow();
+        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                | WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
+
+        Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            public void run() {
+                WakeUp.this.finish();
+            }
+        }, 200);
+    }
+}


### PR DESCRIPTION
When running calabash tests while the phone is locked, tests fail because in that state it is not possible to access the UI.
These changes adds a little Activity to the test server backend which will be started before running each feature and that will ensure the screen is not locked.
This should cover cases commented in this issue: calabash/calabash-android#121
