### PR TITLE
Fixed #135

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -395,7 +395,7 @@ module Operations
     ni
   end
 
-  def background(secs)
+  def app_to_background(secs)
     ni
   end
 


### PR DESCRIPTION
The problem seems to be a simple name collision between Calabash and Cucumber
for the use of the keyword "background".

Renaming Calabash (not yet implemented) "background" operation to app_to_background
solves the issue.

Even if this in theory breaks backwards compatibility, since the operation hadn't
been implemented yet it's going to hardly bother anybody.
