### PR TITLE
Remove any test location providers

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
@@ -74,8 +74,8 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2 {
     private static void removeTestLocationProviders(Activity activity) {
         final LocationManager locationService =
             (LocationManager) activity.getSystemService(Context.LOCATION_SERVICE);
-        locationService.removeTestProvider(LocationManager.GPS_PROVIDER);
-        locationService.removeTestProvider(LocationManager.NETWORK_PROVIDER);
-        locationService.removeTestProvider(LocationManager.PASSIVE_PROVIDER);
+        for (final String provider : locationService.getAllProviders()) {
+            locationService.removeTestProvider(provider);
+        }
     }
 }


### PR DESCRIPTION
Hi,

I've been doing some location testing with calabash. The test would work fine, but afterwards my app wouldn't receive further location updates until the phone was restarted. Other location aware apps were the same: they'd work until before I ran a scenario, but would stop working afterwards.

I suspect that the LocationManager's test providers are global, and that they are left in place after calabash has finished. The attached code is my attempt to remove the test providers when calabash
closes down. I'm not sure if this is the best place to hook into the calabash-android lifecycle, but it seems to work for me. Using this my phone behaves normally after calabash has finished.

Cheers,

Mick
