### PR TITLE
Add delete documentation

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/ClearAppData.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/ClearAppData.java
@@ -19,14 +19,16 @@ public class ClearAppData extends InstrumentationTestRunner {
         }
 	}
 
-    private void delete(File file_or_directory) {
+    /** Deletes the file or all the files contained in a folder recursively. **/
+    private static void delete(File file_or_directory) {
         if (file_or_directory == null) {
             return;
         }
 
         if (file_or_directory.isDirectory()) {
-            if (file_or_directory.listFiles() != null) {
-                for(File f : file_or_directory.listFiles()) {
+            Files[] files = file_or_directory.listFiles();
+            if (files != null) {
+                for(File f : files) {
                     delete(f);
                 }
             }


### PR DESCRIPTION
Delete is static to make it clear instance vars are not used.
Only call listFiles once for performance reasons and code readability.

Based on comments from https://github.com/calabash/calabash-android/commit/cfa37f52e9d7e0adae18df05c7aab5d30af7856a#commitcomment-2273613

The static and listFiles is probably up to personal taste. There should be a note though because one might think delete includes directories as well.
