### PR TITLE
Fix nil error

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -125,7 +125,7 @@ end
 
 def extract_md5_fingerprint(fingerprints)
   m = fingerprints.scan(/MD5:\s+((?:\h\h:){15}\h\h)/)
-  raise "No MD5 fingerprint found:\n #{fingerprints}" unless m
+  raise "No MD5 fingerprint found:\n #{fingerprints}" unless m.first
   m.last.first
 end
 


### PR DESCRIPTION
scan returns [] when not found so check for m.first instead of m.

1.9.3-p194 :004 > ''.scan 'a'
 => []
