### PR TITLE
Cannot extract MD5 when testing with calabash-android-pre6

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -122,7 +122,7 @@ def extract_md5_fingerprint(fingerprints)
     end
   end
 
-  m = fingerprints.scan(/MD5\s*:\s*((?:\h\h:){15}\h\h)/).flatten
+  m = fingerprints.scan(/MD5\s*:\s*((?:[a-fA-F\d]{2}:){15}[a-fA-F\d]{2})/).flatten
   raise "No MD5 fingerprint found:\n #{fingerprints}" if m.empty?
   m.first
 end


### PR DESCRIPTION
Problem: When trying to test with  calabash-android-pre6, got following error:

Alias name: androiddebugkey
Creation date: Aug 17, 2012
Entry type: PrivateKeyEntry
Certificate chain length: 1
Certificate[1]:
Owner: CN=Android Debug, O=Android, C=US
Issuer: CN=Android Debug, O=Android, C=US
Serial number: 502e001e
Valid from: Fri Aug 17 16:26:06 CST 2012 until: Sun Aug 10 16:26:06 CST 2042
Certificate fingerprints:
     MD5:  66:F8:17:EC:A5:59:94:1E:4C:C7:48:39:4E:D9:9A:BF
     SHA1: 77:1D:41:40:9E:84:65:67:F5:9E:EB:C6:5C:12:0E:68:BE:24:0A:9E
     Signature algorithm name: SHA1withRSA
     Version: 3
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/gems/calabash-android-0.4.0.pre6/lib/calabash-android/helpers.rb:93:in `fingerprint_from_keystore'
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/gems/calabash-android-0.4.0.pre6/bin/calabash-android-build.rb:3:in`calabash_build'
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/gems/calabash-android-0.4.0.pre6/bin/calabash-android-run.rb:22:in `calabash_run'
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/gems/calabash-android-0.4.0.pre6/bin/calabash-android:58
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/bin/calabash-android:19:in`load'
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/bin/calabash-android:19
    from /Users/twer/.rvm/gems/ruby-1.8.7-p334@local/bin/ruby_noexec_wrapper:14

Reason: the \h is not supported by ruby-1.8.7-p334
Fix: use [a-fA-F\d]
