### PR TITLE
Always quote keystore location

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -59,7 +59,7 @@ def sign_apk(app_path, dest_path)
     jarsigner_path = "jarsigner"
   end
 
-  cmd = "#{jarsigner_path} -sigalg MD5withRSA -digestalg SHA1 -signedjar #{dest_path} -storepass #{keystore["keystore_password"]} -keystore \"#{File.expand_path keystore["keystore_location"]}\" #{app_path} #{keystore["keystore_alias"]}"
+  cmd = "#{jarsigner_path} -sigalg MD5withRSA -digestalg SHA1 -signedjar #{dest_path} -storepass #{keystore["keystore_password"]} -keystore #{keystore["keystore_location"]} #{app_path} #{keystore["keystore_alias"]}"
   log cmd
   unless system(cmd)
     puts "jarsigner command: #{cmd}"
@@ -69,10 +69,11 @@ end
 
 def read_keystore_info
   if File.exist? ".calabash_settings"
-    JSON.parse(IO.read(".calabash_settings"))
+    keystore = JSON.parse(IO.read(".calabash_settings"))
+    keystore["keystore_location"] = '"' + File.expand_path(keystore["keystore_location"]) + '"' if keystore["keystore_location"]
   else
     {
-    "keystore_location" => "#{ENV["HOME"]}/.android/debug.keystore",
+    "keystore_location" => %Q("#{File.expand_path(File.join(ENV["HOME"], "/.android/debug.keystore"))}\"),
     "keystore_password" => "android",
     "keystore_alias" => "androiddebugkey",
     }


### PR DESCRIPTION
Quote keystore location upon creation so you don't have to expand path and add quotes each time.

``` ruby
 "-keystore #{keystore_info["keystore_location"]} -s"
```

The above is broken on master because it's not expanded or quoted.

Edit: This may be fixed in pre10? It's not on GitHub yet that I can see.
