### PR TITLE
Fixed #218

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/wait/WaitForScreen.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/wait/WaitForScreen.java
@@ -16,7 +16,7 @@ public class WaitForScreen implements Action {
             if (InstrumentationBackend.solo.waitForActivity(args[0], DEFAULT_TIMEOUT)) {
                 return Result.successResult();
             } else {
-            	String currentActivity = InstrumentationBackend.solo.getCurrentActivity().getLocalClassName();
+            	String currentActivity = InstrumentationBackend.solo.getCurrentActivity().getClass().getSimpleName();
             	Result result = new Result(false, "Screen " + args[0] + " not found.  Current activity is " + currentActivity);
             	result.addBonusInformation(currentActivity);
             	return result;
@@ -35,7 +35,7 @@ public class WaitForScreen implements Action {
             if (InstrumentationBackend.solo.waitForActivity(args[0], timeout)) {
                 return Result.successResult();
             } else {
-                String currentActivity = InstrumentationBackend.solo.getCurrentActivity().getLocalClassName();
+                String currentActivity = InstrumentationBackend.solo.getCurrentActivity().getClass().getSimpleName();
             	Result result = new Result(false, "Screen " + args[0] + " not found.  Current activity is " + currentActivity);
             	result.addBonusInformation(currentActivity);
             	return result;


### PR DESCRIPTION
Now using getClass().getSimpleName() to report an error when the activity cannot be found. This what Robotium uses, so this will get developers better information when there is a problem.
