### PR TITLE
Fix for closable leak

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/Actions.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/Actions.java
@@ -42,7 +42,8 @@ public class Actions {
                     addAction(element);
                 }
             }
-        } catch (Exception e) {
+            dexFile.close();
+	} catch (Exception e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
In strictmode, the app will crash unless this file is closed.
