### PR TITLE
Fixed #237: app_running? is more reliable now

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -215,7 +215,11 @@ module Operations
     end
 
     def app_running?
-      `#{adb_command} shell ps`.include?(ENV["PROCESS_NAME"] || package_name(@app_path))
+      begin
+        http("/ping") == "pong"
+      rescue
+        false
+      end
     end
 
     def keyguard_enabled?
@@ -256,11 +260,7 @@ module Operations
         resp = http.post(path, "#{data.to_json}", {"Content-Type" => "application/json;charset=utf-8"})
         resp.body
       rescue Exception => e
-        if app_running?
           raise e
-        else
-          raise "App no longer running"
-        end
       end
     end
 


### PR DESCRIPTION
Hi @jonasmaturana,

Have a look at the commit, the only slightly odd thing I've done is removing the call to app_running? when catching an exception during a http() call.

The reason for this is that since the new app_runnning implementation calls http(), there would be an infinite loop.

Kudos to @kikyoungkwon for the original fix on the ustwo repo.
