### PR TITLE
Typo in AndroidManifest

### DIFF
--- a/ruby-gem/test-server/AndroidManifest.xml
+++ b/ruby-gem/test-server/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COURSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
Through logcat, I saw a tiny error:
W/PackageManager(  169): Unknown permission       android.permission.ACCESS_COURSE_LOCATION in package SomeProject.test
This should       be ACCESS_COARSE_LOCATION, with an A
