### PR TITLE
added update_app to operations.rb

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -217,14 +217,13 @@ module Operations
       cmd = "#{adb_command} install -r \"#{app_path}\""
       log "Updating: #{app_path}"
       result = `#{cmd}`
-      log result
-      pn = package_name(app_path)
-      succeeded = `#{adb_command} shell pm list packages`.include?("package:#{pn}")
+      log "result: #{result}"
+      succeeded = result.include?("Success")
 
       unless succeeded
         ::Cucumber.wants_to_quit = true
         raise "#{pn} did not get updated. Aborting!"
-      end
+      end    
     end
 
     def uninstall_app(package_name)


### PR DESCRIPTION
To enable testing migrations from older versions of an app to a new one, I wanted to install the app without clearing the data from the old version.

I added a update_app method to operations.rb that uses the adb install -r option.  
