### PR TITLE
Fixed off-by-one error in When I press list item number ...

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/press_button_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/press_button_steps.rb
@@ -27,7 +27,7 @@ Then /^I touch the "([^\"]*)" text$/ do |text|
 end
 
 Then /^I press list item number (\d+)$/ do |line_index|
-  performAction('press_list_item', line_index, 0)
+  performAction('press_list_item', line_index.to_i+1, 0)
 end
 
 Then /^I long press list item number (\d+)$/ do |line_index|


### PR DESCRIPTION
When I press list item number 4
When I press list item number 3
When I press list item number 2
When I press list item number 1

pressed item 3,2,1,1, in that order.
Adding a +1 to each index of course fixes this.
