### PR TITLE
Make activity tracking reliable (robotium issue 179)

### DIFF
--- a/ruby-gem/test-server/build.xml
+++ b/ruby-gem/test-server/build.xml
@@ -17,7 +17,7 @@
     <condition property="bat" value=".bat" else=""><os family="windows" /></condition>
 
     <property name="dx" location="${tools.dir}/dx${bat}" />
-    <property name="aapt" location="${tools.dir}/aapt${bat}" />
+    <property name="aapt" location="${tools.dir}/aapt" />
     
     <property name="android.lib" location="${env.ANDROID_HOME}/platforms/android-${android.api.level}/android.jar"/>
     <path id="android.antlibs">

--- a/ruby-gem/test-server/instrumentation-backend/.classpath
+++ b/ruby-gem/test-server/instrumentation-backend/.classpath
@@ -2,10 +2,8 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="src" path="assets"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry kind="lib" path="libs/robotium-solo-3.6.jar"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
@@ -2,15 +2,14 @@ package com.jayway.android.robotium.solo;
 
 import java.util.List;
 
-import android.app.Activity;
 import android.app.Instrumentation;
 
 public class SoloEnhanced extends Solo {
 //	private Pincher pincher;
 	private MapViewUtils mapViewUtils;
 
-	public SoloEnhanced(Instrumentation instrumentation, Activity activity) {
-		super(instrumentation, activity);
+	public SoloEnhanced(Instrumentation instrumentation) {
+		super(instrumentation);
 		this.mapViewUtils = new MapViewUtils(instrumentation, viewFetcher, sleeper, waiter);
 //		this.pincher = new Pincher(instrumentation, viewFetcher);
 	}

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/CalabashInstrumentationTestRunner.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/CalabashInstrumentationTestRunner.java
@@ -2,6 +2,7 @@ package sh.calaba.instrumentationbackend;
 
 import java.lang.reflect.Method;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.test.InstrumentationTestRunner;
@@ -27,7 +28,7 @@ public class CalabashInstrumentationTestRunner extends InstrumentationTestRunner
         InstrumentationBackend.extras = arguments;
 
         try {
-            InstrumentationBackend.mainActivity = Class.forName(arguments.getString("main_activity"));
+            InstrumentationBackend.mainActivity = Class.forName(arguments.getString("main_activity")).asSubclass(Activity.class);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
@@ -16,9 +16,9 @@ import android.util.Log;
 import com.jayway.android.robotium.solo.PublicViewFetcher;
 import com.jayway.android.robotium.solo.SoloEnhanced;
 
-public class InstrumentationBackend extends ActivityInstrumentationTestCase2 {
+public class InstrumentationBackend extends ActivityInstrumentationTestCase2<Activity> {
     public static String testPackage;
-    public static Class mainActivity;
+    public static Class<? extends Activity> mainActivity;
     public static Bundle extras;
     
     private static final String TAG = "InstrumentationBackend";
@@ -28,8 +28,9 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2 {
     public static PublicViewFetcher viewFetcher;
     public static Actions actions;
 
+    @SuppressWarnings({ "deprecation", "unchecked" })
     public InstrumentationBackend() {
-        super(testPackage, mainActivity);
+        super(testPackage, (Class<Activity>) mainActivity);
     }
 
     @Override
@@ -39,7 +40,7 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2 {
         i.setClassName(testPackage, mainActivity.getName());
         i.putExtras(extras);
         setActivityIntent(i);
-        solo = new SoloEnhanced(getInstrumentation(), this.getActivity());
+        solo = new SoloEnhanced(getInstrumentation());
         viewFetcher = new PublicViewFetcher(getInstrumentation(), this.getActivity());
         actions = new Actions(getInstrumentation(), this);
         instrumentation = getInstrumentation();


### PR DESCRIPTION
Use the recommended constructor for robotium.Solo()

This makes activity tracking work reliably when the main activity of the
application starts other activities immediately.

See https://code.google.com/p/robotium/issues/detail?id=179

Also fix some warnings at the same time.

Also tweak some build settings
- aapt is no longer a batch file on windows
- assets shouldn't be a source director for Eclipse
- libraries don't need to be added to the build path manually in Eclipse
