### PR TITLE
Persistently allocate server ports to devices

### DIFF
--- a/ruby-gem/bin/calabash-android-console.rb
+++ b/ruby-gem/bin/calabash-android-console.rb
@@ -1,10 +1,6 @@
 def calabash_console(app_path = nil)
   test_server_path = test_server_path(app_path)
 
-  unless ENV["TEST_SERVER_PORT"]
-    ENV["TEST_SERVER_PORT"] = "34777"
-  end
-
   ENV["IRBRC"] = File.join(File.dirname(__FILE__), '..', 'irbrc')
 
   unless ENV["MAIN_ACTIVITY"]

--- a/ruby-gem/bin/calabash-android-run.rb
+++ b/ruby-gem/bin/calabash-android-run.rb
@@ -16,15 +16,9 @@ def calabash_run(app_path = nil)
     build_test_server_if_needed(app_path)
 
     test_server_path = test_server_path(app_path)
-    if ENV["TEST_SERVER_PORT"]
-      test_server_port = ENV["TEST_SERVER_PORT"]
-    else
-      test_server_port = "34777"
-    end
     env = "MAIN_ACTIVITY=#{main_activity(app_path)} "\
           "APP_PATH=\"#{app_path}\" "\
-          "TEST_APP_PATH=\"#{test_server_path}\" "\
-          "TEST_SERVER_PORT=#{test_server_port}"
+          "TEST_APP_PATH=\"#{test_server_path}\""
   else
     env = ""
   end

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -178,8 +178,8 @@ module Operations
     def initialize(cucumber_world, serial, server_port, app_path, test_server_path, test_server_port = 7102)
 
       @cucumber_world = cucumber_world
-      @serial = serial
-      @server_port = server_port
+      @serial = serial || default_serial
+      @server_port = server_port || default_server_port
       @app_path = app_path
       @test_server_path = test_server_path
       @test_server_port = test_server_port
@@ -400,16 +400,33 @@ module Operations
       end
     end
 
-    def serial
-      @serial || default_serial
-    end
-
     def default_serial
       devices = connected_devices
       log "connected_devices: #{devices}"
       raise "No connected devices" if devices.empty?
       raise "More than one device connected. Specify device serial using ADB_DEVICE_ARG" if devices.length > 1
       devices.first
+    end
+
+    def default_server_port
+      require 'yaml'
+      File.open(File.expand_path('~/.calabash.yaml'), File::RDWR|File::CREAT) do |f|
+        f.flock(File::LOCK_EX)
+        state = YAML::load(f) || {}
+        ports = state['server_ports'] ||= {}
+        return ports[serial] if ports.has_key?(serial)
+
+        port = 34777
+        port += 1 while ports.has_value?(port)
+        ports[serial] = port
+
+        f.rewind
+        f.write(YAML::dump(state))
+        f.truncate(f.pos)
+
+        log "Persistently allocated port #{port} to #{serial}"
+        return port
+      end
     end
 
     def connected_devices


### PR DESCRIPTION
This makes running against different devices (possibly at the same time)
easier by keeping a persistent mapping between device serials and ports
in ~/.calabash.yaml
