### PR TITLE
Fix list item indexing

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/list/PressListItems.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/list/PressListItems.java
@@ -10,7 +10,7 @@ public class PressListItems implements Action {
 
     @Override
     public Result execute(String... args) {
-        InstrumentationBackend.solo.clickInList(Integer.parseInt(args[0]) - 1, Integer.parseInt(args[1]));
+        InstrumentationBackend.solo.clickInList(Integer.parseInt(args[0]), Integer.parseInt(args[1]));
         return Result.successResult();
     }
 


### PR DESCRIPTION
Robotium seems to use 1-based list indices and not 0-based.
Removed the "-1" from the first argument, otherwise clicking the 2nd item in a list would be press_list_item(3) which is confusing and semantically wrong.
