### PR TITLE
Added steps for verifying logcat output and pushing files to the device

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -51,6 +51,32 @@ module Operations
     default_device.perform_action(action, *arguments)
   end
 
+  def clear_logcat
+      `#{default_device.adb_command} logcat -c`
+  end
+
+  def emitted_via_logcat(text, tag=nil, loglevel='V')
+    if tag
+      (`#{default_device.adb_command} logcat -d #{tag}:#{loglevel} *:S`).include? text
+    else
+      (`#{default_device.adb_command} logcat -d *:#{loglevel}`).include? text
+    end
+  end
+
+  def get_levels_emitted_via_logcat(tag='*')
+    events = Hash.new()
+
+    # put each of the event types in
+    (`#{default_device.adb_command} logcat -d #{tag}:VERBOSE *:S`).split("\n").each do |line| 
+          c = line.chars.first
+          ordered = 'EWIDV'
+          # assign the ordeing of log priority
+          events[c] = ordered.index c if ordered.include? c
+      end
+
+    events
+  end
+  
   def reinstall_apps
     default_device.reinstall_apps
   end

--- a/ruby-gem/lib/calabash-android/steps/adb_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/adb_steps.rb
@@ -1,0 +1,33 @@
+
+Then /^I see "([^\"]*)" in the ADB logs$/ do |text|
+  raise "Did not see string #{text} in ADB logs" unless emitted_via_logcat(text)
+end
+
+Given /^I clear the ADB logs$/ do
+  clear_logcat
+end
+
+Then /^I see "([^\"]*)" in the ADB logs with the tag "([^\"]*)"$/ do |text, tag|
+  raise "Did not see string #{text} in ADB logs with tag #{tag}" unless emitted_via_logcat(text, tag)
+end
+
+Then /^I see "([^\"]*)" in the ADB logs at the "([^\"]*)" level $/ do |text, level|
+  raise "Did not see string #{text} in ADB logs with tag #{tag}" unless emitted_via_logcat(text, level=level.upcase.chars.first)
+end
+
+Then /^I see "([^\"]*)" in the ADB logs with the tag "([^\"]*)" at the "([^\"]*)" level $/ do |text, tag, level|
+  raise "Did not see string #{text} in ADB logs with tag #{tag} at log level #{level.upcase}" unless emitted_via_logcat(text, tag, level.upcase.chars.first)
+end
+
+Then /^I (?:have pushed|push) "([^\"]*)" to "([^\"]*)" on the device$/ do |src, dst|
+	push(src, dst)
+end
+
+Then /^I only see logs with the tag "([^\"]*)" below the "([^\"]*)" level$/ do |tag, level|
+	log_levels = get_levels_emitted_via_logcat(tag)
+
+	level_ord = 'EWIDV'.index(level.upcase.chars.first)
+
+	# see if we have any higher log levels?
+	raise "Found higher log levels than #{level}:#{level_ord} in all levels: #{log_levels.keys.join(' ')}" unless (log_levels.keys.select { |key| log_levels[key] > level_ord }).empty?
+end


### PR DESCRIPTION
I added three methods to `operations.rb`:
1. clear_logcat: clears the logcat buffer to ensure clean tests
2. emitted_via_logcat: searches the logcat logs for a specific substring. Can filter by tag or level.
3. get_levels_emitted_via_logcat: creates a hashtable of log levels emitted along with priority. Useful for verifying log filtering features in an app.

I also added a step for pushing a test file to the device.
