### PR TITLE
Complain if ant is too old.

### DIFF
--- a/ruby-gem/test-server/build.xml
+++ b/ruby-gem/test-server/build.xml
@@ -44,6 +44,14 @@
       <fail unless="doesCalabashJsExist">
         ${calabashjs.dir} does not exist.
       </fail>
+      <antversion property="version.running" />
+      <fail message="FATAL ERROR:  The running Ant version, ${version.running}, is too old.">
+        <condition>
+          <not>
+            <antversion atleast="1.8" />
+          </not>
+        </condition>
+      </fail>
     </target>
 
     <target name="-stage">


### PR DESCRIPTION
Ant 1.7 gives some very strange errors when you try to compile calabash-android.
I propose to add the following check which displays a nice error instead.
