### PR TITLE
Fixes problem with current_activity on KitKat

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -22,7 +22,7 @@ module Operations
   include Calabash::Android::TouchHelpers
 
   def current_activity
-    `#{default_device.adb_command} shell dumpsys window windows`.each_line.grep(/mFocusedApp.+[\.\/]([^.\/\}]+)\}/){$1}.first
+    `#{default_device.adb_command} shell dumpsys window windows`.each_line.grep(/mFocusedApp.+[\.\/]([^.\/\}]+)\}/){$1}.first.split.first
   end
 
   def log(message)


### PR DESCRIPTION
I'm getting weird characters at the end of the string on my HTC One with KitKat when calling `current_activity`.
Here is a quick and dirty patch.

This won't cause any undesired side effects since split will work the same if the weird characters are not there

``` ruby
irb(main):001:0> start_test_server_in_background
nil
irb(main):002:0> current_activity
"SidebarContentActivity t144"
irb(main):003:0> current_activity.split.first
"SidebarContentActivity"
```
