### PR TITLE
Run irb in-process instead of via system()

### DIFF
--- a/ruby-gem/bin/calabash-android-console.rb
+++ b/ruby-gem/bin/calabash-android-console.rb
@@ -17,5 +17,6 @@ def calabash_console(app_path = nil)
 
   build_test_server_if_needed(app_path)
 
-  system "#{RbConfig.ruby} -S irb"
+  require 'irb'
+  IRB.start
 end


### PR DESCRIPTION
This preserves the ruby environment as setup up (e.g.) via bundler exec

I'm not sure if this necessitates any changes in irbrc (or makes some of the code that is in there currently redundant), however everything still seems to work.
