### PR TITLE
Create Solo before starting first activity

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
@@ -9,8 +9,8 @@ import android.graphics.PointF;
 public class SoloEnhanced extends Solo {
 	private MapViewUtils mapViewUtils;
 
-	public SoloEnhanced(Instrumentation instrumentation, Activity activity) {
-		super(instrumentation, activity);
+	public SoloEnhanced(Instrumentation instrumentation) {
+		super(instrumentation);
 		this.mapViewUtils = new MapViewUtils(instrumentation, viewFetcher, sleeper, waiter);
 	}
     public ActivityUtils getActivityUtils() {

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
@@ -56,6 +56,7 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2<Act
      */
 
     public void testHook() throws Exception {
+        solo = new SoloEnhanced(getInstrumentation());
 
         final AtomicReference<Activity> activityReference = new AtomicReference<Activity>();
         Thread activityStarter = new Thread() {
@@ -105,7 +106,6 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2<Act
             }
         }
         if (activity != null) {
-            solo = new SoloEnhanced(getInstrumentation(), activity);
             setActivity(activity);
 
             viewFetcher = new PublicViewFetcher(solo.getActivityUtils());


### PR DESCRIPTION
This ensures that robotium can correctly track additional activities that
are started.