### PR TITLE
Return 'path' property for query results

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/QueryResult.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/QueryResult.java
@@ -28,12 +28,12 @@ public class QueryResult {
         }
     }
 
-    public List<?> getResult() {
+    public List getResult() {
         return result;
     }
 
 
-    public List<?> asList() {
+    public List asList() {
         return ViewMapper.mapViews(result);
     }
 }

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/QueryResult.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/QueryResult.java
@@ -1,16 +1,17 @@
 package sh.calaba.instrumentationbackend.query;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import sh.calaba.org.codehaus.jackson.map.ObjectMapper;
 
 public class QueryResult {
 
-    private List result;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public QueryResult(List result) {
+    private List<?> result;
+
+    public QueryResult(List<?> result) {
 
         this.result = result;
     }
@@ -20,26 +21,19 @@ public class QueryResult {
     }
 
     public String asJson() {
-        ObjectMapper mapper = new ObjectMapper();
-
         try {
-            return mapper.writeValueAsString(result);
+            return MAPPER.writeValueAsString(result);
         } catch (IOException e) {
             throw new RuntimeException("Could not convert result to json", e);
         }
     }
 
-    public List getResult() {
+    public List<?> getResult() {
         return result;
     }
 
 
-    public List asList() {
-        List<Object> finalResult = new ArrayList(result.size());
-        for (Object o : result) {
-            finalResult.add(ViewMapper.mapView(o));
-        }
-        return finalResult;
+    public List<?> asList() {
+        return ViewMapper.mapViews(result);
     }
-
 }

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
@@ -194,13 +194,12 @@ public class UIQueryUtils {
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public static Future evaluateAsyncInMainThread(final Callable callable) throws Exception {
+	public static <T> Future<T> evaluateAsyncInMainThread(final Callable<T> callable) throws Exception {
 
 		final AtomicReference<Future> result = new AtomicReference<Future>();
 		final AtomicReference<Exception> errorResult = new AtomicReference<Exception>();
 
 		InstrumentationBackend.instrumentation.runOnMainSync(new Runnable() {
-			@SuppressWarnings("unchecked")
 			public void run() {
 				try {
 					Object res = callable.call();
@@ -220,8 +219,7 @@ public class UIQueryUtils {
 		return result.get();
 	}
 
-	@SuppressWarnings("rawtypes")
-	public static Object evaluateSyncInMainThread(Callable callable) {
+	public static <T> T evaluateSyncInMainThread(Callable<T> callable) {
 		try {
 			return evaluateAsyncInMainThread(callable)
 					.get(10, TimeUnit.SECONDS);


### PR DESCRIPTION
This allows the hierarchical relationships between returned
views to be re-constructed on the Ruby side. Also change the
View mapping to happen on the main thread.