### PR TITLE
Handling spaces in the path to aapt command if ANDROID_HOME path has spaces

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -22,8 +22,12 @@ def main_activity(app)
 end
 
 def aapt_dump(app, key)
-  lines = `#{Env.tools_dir}/aapt dump badging "#{app}"`.lines.collect(&:strip)
+  lines = `#{aapt_command} dump badging "#{app}"`.lines.collect(&:strip)
   lines.select { |l| l.start_with?("#{key}:") }
+end
+
+def aapt_command()
+  "\"#{Env.tools_dir}/aapt\""
 end
 
 def checksum(file_path)
@@ -60,11 +64,11 @@ def resign_apk(app_path)
 end
 
 def unsign_apk(path)
-  files_to_remove = `#{Env.tools_dir}/aapt list "#{path}"`.lines.collect(&:strip).grep(/^META-INF\//)
+  files_to_remove = `#{aapt_command} list "#{path}"`.lines.collect(&:strip).grep(/^META-INF\//)
   if files_to_remove.empty?
     log "App wasn't signed. Will not try to unsign it."
   else
-    system("#{Env.tools_dir}/aapt remove \"#{path}\" #{files_to_remove.join(" ")}")
+    system("#{aapt_command} remove \"#{path}\" #{files_to_remove.join(" ")}")
   end
 end
 


### PR DESCRIPTION
This handles spaces in the ANDROID_HOME  path while calling the aapt commands. 
Currently "resign", "build" commands do not work if there is a space in the path to the aapt tool (present in the android SDK)
