### PR TITLE
Delete rotation_steps.rb

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/rotation_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/rotation_steps.rb
@@ -1,7 +1,0 @@
-Then /^I rotate the device to landscape$/ do
-  rotate_phone(90)
-end
-
-Then /^I rotate the device to portrait$/ do
-  rotate_phone(0)
-end


### PR DESCRIPTION
rotate_phone is not a defined method, steps fail.
