### PR TITLE
Fix issue 377 with Kony app start

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
@@ -42,7 +42,8 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2<Act
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        Intent i = new Intent();
+        Intent i = new Intent(Intent.ACTION_MAIN);
+        i.addCategory("android.intent.category.LAUNCHER");
         i.setClassName(testPackage, mainActivity.getName());
         i.putExtras(extras);
         setActivityIntent(i);


### PR DESCRIPTION
Some Titanium apps just flashed when Calabash tried to start them.
This fix starts the applications properly.
