### PR TITLE
fixes calabash-android console command for rvm users

### DIFF
--- a/ruby-gem/bin/calabash-android-console.rb
+++ b/ruby-gem/bin/calabash-android-console.rb
@@ -33,6 +33,5 @@ def calabash_console(app_path = nil)
   puts 'Starting calabash-android console...'
   puts "Loading #{ENV['IRBRC']}"
   puts 'Running irb...'
-  exec('irb')
-
+  system "#{RbConfig.ruby} -S irb"
 end


### PR DESCRIPTION
## motivation

Fixes `calabash-android console` command for rvm users.
- https://github.com/calabash/calabash-android/pull/352
- https://github.com/calabash/calabash-android/issues/371
## action items

This pull request needs review by rvm users and the primary gem maintainers.
- [ ] @gregeng
- [x] @krukow 
- [ ] @jonasmaturana 
- [ ] @TobiasRoikjer 

I would prefer it if a primary maintainer merged this pull request.
## which irbrc should be used?

```
# define a custom .irbrc file using the CALABASH_IRBRC variable
$ CALABASH_IRBRC=~/.irbrc calabash-android console ...

# if a .irbrc file exists in the current directory, load that .irbrc
$ calabash-android console ...
Starting calabash-android console...
Loading /Users/rvm/git/some-project/.irbrc
Running irb...

# if CALABASH_IRBRC is not available and there is no local .irbrc file
# load the calabash-android gem irbrc file
$ calabash-android console ...
$ be calabash-android console ../../app/tesco/tesco.apk 
Starting calabash-android console...
Loading /path/to/calabash-android/gem/irbrc
Running irb...
```
### launch irb with exec

I also changed how the irb is launched.

I think the right thing to do is launch the irb with `exec`.

Using `exec` will swap the current process (the ruby script) with `irb`.

The original code did this:

```
system "#{RbConfig.ruby} -S irb"
```

`system(cmd)` runs `cmd` in a new process.  In this case it invokes irb using `ruby` in the context of the original ruby process.  While this obviously has been working, I think that it is cleaner to use `exec`.

If you disagree, just merge with the first commit.
- @Goginenni
- @balazsbalazs
- @thestumonkey
- @jurgisl
- @jescriba 
- @chazbites
