### PR TITLE
Update instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains support for Android, for iOS, see [Calabash Landing Pag
 
 Calabash is a free open source project, developed and maintained by [Xamarin](http://xamarin.com).
 
-While Calabash is completely free, Xamarin provides a number of commercial services centered around Calabash and quality assurance for mobile, namely Xamarin Test Cloud consisting of hosted test-execution environments which let you execute Calabash tests on a large number of Android and iOS devices. 
+While Calabash is completely free, Xamarin provides a number of commercial services centered around Calabash and quality assurance for mobile, namely Xamarin Test Cloud consisting of hosted test-execution environments which let you execute Calabash tests on a large number of Android and iOS devices.
 
 Please see [xamarin.com/test-cloud](http://xamarin.com/test-cloud).
 
@@ -44,7 +44,27 @@ Running test
 ------------
 To run your test:
 
-    calabash-android run <apk>
+- Build apk
+- Resign apk (optional, you'll require this step if your apk is signed)
+
+        calabash-android resign <apk>
+
+- Build test server apk (result is saved in `test_servers` directory)
+
+        calabash-android build <apk>
+
+- Run test
+
+
+        # set required environment variables
+        export APP_PATH=<apk>
+        export TEST_APP_PATH=test_servers/<test_server_apk>
+        # run "default" profile from cucumber.yml
+        calabash-android run
+        # run your custom "regression" profile
+        calabash-android run --profile regression
+        # run using tags
+        calabash-android run --tags @smoke,@regression --tags ~@debug
 
 Calabash-android will install an instrumentation along with your app when executing the app. We call this instrumentation for "test server". The "test server" has special permission that allows it to interact very closely with your app during test.
 Everytime you test a new binary or use an upgraded version of calabash a new test server will be build.


### PR DESCRIPTION
Wiki is lacking some of the important steps needed to run tests successfully.
- How to resign apk if it was originally signed
- How to build test server apk
- How to run with cucumber options like `--profile` or `--tags` (#365)

This is an update to README.md to provide more information.