### PR TITLE
Query by tag, tag property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains support for Android, for iOS, see [Calabash Landing Pag
 
 Calabash is a free open source project, developed and maintained by [Xamarin](http://xamarin.com).
 
-While Calabash is completely free, Xamarin provides a number of commercial services centered around Calabash and quality assurance for mobile, namely Xamarin Test Cloud consisting of hosted test-execution environments which let you execute Calabash tests on a large number of Android and iOS devices. 
+While Calabash is completely free, Xamarin provides a number of commercial services centered around Calabash and quality assurance for mobile, namely Xamarin Test Cloud consisting of hosted test-execution environments which let you execute Calabash tests on a large number of Android and iOS devices.
 
 Please see [xamarin.com/test-cloud](http://xamarin.com/test-cloud).
 

--- a/ruby-gem/test-server/instrumentation-backend/antlr/UIQuery.g
+++ b/ruby-gem/test-server/instrumentation-backend/antlr/UIQuery.g
@@ -32,13 +32,13 @@ options {
   }
 }
 
-query	:	expr (WHITE! expr)*  
+query	:	expr (WHITE! expr)*
 		;
-	
 
-expr	:	(className | filter | visibility | predicate | DIRECTION^) 
+
+expr	:	(className | filter | visibility | predicate | DIRECTION^)
 		;
-		
+
 DIRECTION : 'descendant' | 'child' | 'parent' | 'sibling'
 		;
 
@@ -66,12 +66,12 @@ BEGINPRED : '{'
 	;
 ENDPRED	  : '}'
 	;
-	
-RELATION : | '=' | '>' | '>=' | '<' | '<=' | 
-			(( 'BEGINSWITH' | 'ENDSWITH' | 'CONTAINS' | 'LIKE' 
+
+RELATION : | '=' | '>' | '>=' | '<' | '<=' | '!=' | '<>' |
+			(( 'BEGINSWITH' | 'ENDSWITH' | 'CONTAINS' | 'LIKE'
 		       | 'beginswith' | 'endswith' | 'contains' | 'like') ('[' ('a'..'z' | 'A'..'Z')* ']')?)
-		       
-	; 
+
+	;
 
 INT :	'0'..'9'+
     ;
@@ -86,8 +86,8 @@ NAME  :	('a'..'z'|'A'..'Z'|'_') ('a'..'z'|'A'..'Z'|'0'..'9'|'_'|'$')*
     ;
 
 STRING
-    :  '\'' ( ESC_SEQ | ~('\\'|'\'') )* '\'' 
-    |  '"' ( DOUBLE_ESC_SEQ | ~('\\'|'"') )* '"'    
+    :  '\'' ( ESC_SEQ | ~('\\'|'\'') )* '\''
+    |  '"' ( DOUBLE_ESC_SEQ | ~('\\'|'"') )* '"'
     ;
 
 WHITE   :	' '+ ;

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ViewMapper.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ViewMapper.java
@@ -15,15 +15,16 @@ import android.widget.TextView;
 public class ViewMapper {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public static Object extractDataFromView(View v) {		
-		
+	public static Object extractDataFromView(View v) {
+
 		Map data = new HashMap();
-		data.put("class", getClassNameForView(v));		
+		data.put("class", getClassNameForView(v));
 		data.put("description", v.toString());
 		data.put("contentDescription", getContentDescriptionForView(v));
 		data.put("enabled", v.isEnabled());
-		
+
 		data.put("id", getIdForView(v));
+		data.put("tag", getTagForView(v));
 
 		Map rect = getRectForView(v);
 
@@ -52,10 +53,10 @@ public class ViewMapper {
 
 		rect.put("x", location[0]);
 		rect.put("y", location[1]);
-		
+
 		rect.put("center_x", location[0] + v.getWidth()/2.0);
 		rect.put("center_y", location[1] + v.getHeight()/2.0);
-		
+
 		rect.put("width", v.getWidth());
 		rect.put("height", v.getHeight());
 		return rect;
@@ -82,26 +83,33 @@ public class ViewMapper {
 		return id;
 	}
 
+	public static String getTagForView(View v) {
+		if (v.getTag() instanceof String || v.getTag() instanceof Integer) {
+			return v.getTag().toString();
+		}
+		return null;
+	}
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static Object mapView(Object o) {
 		if (o instanceof View) {
 			return extractDataFromView((View) o);
-		} 
-		else if (o instanceof Map) {			
-			Map copy = new HashMap();			
+		}
+		else if (o instanceof Map) {
+			Map copy = new HashMap();
 			for (Object e : ((Map) o).entrySet()) {
 				Map.Entry entry = (Entry) e;
 				Object value = entry.getValue();
 				if (value instanceof View) {
 					copy.put(entry.getKey(), UIQueryUtils.getId((View) value));
-				}				
+				}
 				else {
 					copy.put(entry.getKey(),entry.getValue());
-				}			
+				}
 			}
-			
+
 			return copy;
-		} 
+		}
 		else if (o instanceof CharSequence) {
 			return o.toString();
 		}

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/ComparisonOperator.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/ComparisonOperator.java
@@ -25,7 +25,13 @@ public enum ComparisonOperator implements UIQueryASTPredicateRelation {
 			if (firstValue == secondValue) {
 				return true;
 			}
-			return (firstValue != null) && firstValue.equals(secondValue);					
+			return (firstValue != null) && firstValue.equals(secondValue);
+		}
+	},
+
+	NOTEQUAL {
+		public boolean areRelated(Object firstValue, Object secondValue) {
+			return !EQUAL.areRelated(firstValue, secondValue);
 		}
 	},
 

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTPredicate.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTPredicate.java
@@ -80,6 +80,16 @@ public class UIQueryASTPredicate implements UIQueryAST {
 			}
 		}
 
+		// there's no tag property for non Views, handle them all here
+		if (this.propertyName.equals("tag")) {
+			String tag = (o instanceof View ? UIQueryUtils.getTag((View) o) : null);
+			if (this.relation.areRelated(tag, this.valueToMatch)) {
+				return o;
+			} else {
+				return null;
+			}
+		}
+
 		Method propertyAccessor = UIQueryUtils
 				.hasProperty(o, this.propertyName);
 		if (propertyAccessor == null) {
@@ -109,7 +119,7 @@ public class UIQueryASTPredicate implements UIQueryAST {
 		return new UIQueryASTPredicate(prop.getText(),
 				UIQueryASTPredicate.parseRelation(rel),
 				UIQueryUtils.parseValue(val));
-			
+
 	}
 
 	private static UIQueryASTPredicateRelation parseRelation(CommonTree rel) {
@@ -120,7 +130,7 @@ public class UIQueryASTPredicate implements UIQueryAST {
 			caseSensitive = false;
 			relText = relText.substring(0,relText.length() - CASE_INSENSITIVE_SPEC.length());
 		}
-		
+
 		if ("BEGINSWITH".equals(relText)) {
 			return new BeginsWithRelation(caseSensitive);
 		} else if ("ENDSWITH".equals(relText)) {
@@ -139,6 +149,8 @@ public class UIQueryASTPredicate implements UIQueryAST {
 			return ComparisonOperator.GREATERTHAN;
 		} else if (">=".equals(relText)) {
 			return ComparisonOperator.GREATERTHANOREQUAL;
+		} else if ("!=".equals(relText) || "<>".equals(relText)) {
+			return ComparisonOperator.NOTEQUAL;
 		} else {
 			throw new IllegalStateException("Unsupported Relation: " + relText);
 		}

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
@@ -47,7 +47,7 @@ public class UIQueryUtils {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static List subviews(Object o) {
-		
+
 		try {
 			Method getChild = o.getClass().getMethod("getChildAt", int.class);
 			getChild.setAccessible(true);
@@ -74,15 +74,15 @@ public class UIQueryUtils {
 
 	@SuppressWarnings({ "rawtypes" })
 	public static Future webViewSubViews(WebView o) {
-		
+
 		Log.i("Calabash", "About to webViewSubViews");
-		
+
 
 		WebFuture controls = QueryHelper.executeAsyncJavascriptInWebviews(o,
 				"calabash.js", "input,button","css");
-		
+
 		return controls;
-		
+
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -193,6 +193,10 @@ public class UIQueryUtils {
 		return ViewMapper.getIdForView(view);
 	}
 
+	public static String getTag(View view) {
+		return ViewMapper.getTagForView(view);
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static Future evaluateAsyncInMainThread(final Callable callable) throws Exception {
 
@@ -301,7 +305,7 @@ public class UIQueryUtils {
 	}
 
 	/*
-	 * 
+	 *
 	 * {"rect"=>{"x"=>0, "y"=>0, "width"=>768, "height"=>1024},
 	 * "hit-point"=>{"x"=>384, "y"=>512}, "id"=>"", "action"=>false,
 	 * "enabled"=>1, "visible"=>1, "value"=>nil, "type"=>"[object UIAWindow]",
@@ -343,7 +347,7 @@ public class UIQueryUtils {
 				childrenArray.add(dumpRecursively(serializedChild,
 						childrenList));
 			}
-			
+
 		}
 
 		parentView.put("children", childrenArray);
@@ -373,7 +377,7 @@ public class UIQueryUtils {
 	}
 
 	/*
- * 
+ *
                                             "enabled" => true,
                                             "visible" => true,
                                            "children" => [],
@@ -412,16 +416,16 @@ public class UIQueryUtils {
 		if (viewOrMap == null) {
 			return null;
 		}
-		
-		if (viewOrMap instanceof Map) 
+
+		if (viewOrMap instanceof Map)
 		{
-			Map map = (Map) viewOrMap;			
+			Map map = (Map) viewOrMap;
 			map.put("el", map);
 
 			Map rect = (Map) map.get("rect");
 			Map hitPoint = extractHitPointFromRect(rect);
-			
-			map.put("hit-point", hitPoint);			
+
+			map.put("hit-point", hitPoint);
 			map.put("enabled", true);
 			map.put("visible", true);
 			map.put("value", null);
@@ -430,31 +434,31 @@ public class UIQueryUtils {
 			map.put("label", null);
 			map.put("children", Collections.EMPTY_LIST);
 			String html = (String)map.get("html");
-			String nodeName = (String) map.get("nodeName");			
-			if (nodeName != null && nodeName.toLowerCase().equals("input")) {				
+			String nodeName = (String) map.get("nodeName");
+			if (nodeName != null && nodeName.toLowerCase().equals("input")) {
 				String domType = extractDomType(html);
 				if (isDomPasswordType(domType)) {
 					map.put("entry_types", Collections.singletonList("password"));
 				}
 				else if (isDomTextType(domType)) {
 					map.put("entry_types", Collections.singletonList("text"));
-				} 
+				}
 				else {
-					map.put("entry_types", Collections.emptyList());	
-				}					
+					map.put("entry_types", Collections.emptyList());
+				}
 				map.put("value", extractAttribute(html, "value"));
 				map.put("type", "dom");
 				map.put("name", extractAttribute(html, "name"));
 				map.put("label", extractAttribute(html, "title"));
-			}					
-						
-			return map;	
-			
+			}
+
+			return map;
+
 		}
-		else 
+		else
 		{
 			Map m = new HashMap();
-			
+
 			View view = (View) viewOrMap;
 			m.put("id", getId(view));
 			m.put("el", view);
@@ -472,12 +476,12 @@ public class UIQueryUtils {
 			m.put("type", ViewMapper.getClassNameForView(view));
 			m.put("name", getNameForView(view));
 			m.put("label", ViewMapper.getContentDescriptionForView(view));
-			return m;	
+			return m;
 		}
 
-		
 
-		
+
+
 	}
 
 	private static boolean isDomTextType(String domType) {
@@ -487,25 +491,25 @@ public class UIQueryUtils {
 		return DOM_TEXT_TYPES.contains(domType);
 	}
 
-	private static boolean isDomPasswordType(String domType) {		
+	private static boolean isDomPasswordType(String domType) {
 		return "password".equalsIgnoreCase(domType);
 	}
 
 	// naive implementation only works for (valid) input tags
 	public static String extractDomType(String input) {
-		return extractAttribute(input, "type");		
+		return extractAttribute(input, "type");
 	}
-	
+
 	public static String extractAttribute(String input, String attribute) {
 		String[] split = input.split(attribute+"=");
 		if (split.length == 1) {
-			split = input.split(attribute+" =");			
+			split = input.split(attribute+" =");
 		}
 		if (split.length > 1) {
 			String lastPart = split[1];
 			if (lastPart == null) {
-				return null;	
-			}				
+				return null;
+			}
 			if (lastPart.charAt(0) == '"' || lastPart.charAt(0) == '\'') {
 				int endIndex = -1;
 				for (int i=1;i<lastPart.length();i++) {
@@ -514,15 +518,15 @@ public class UIQueryUtils {
 						break;
 					}
 				}
-				
+
 				if (endIndex > 0) {
 					return lastPart.substring(1,endIndex);
 				}
-				
-			}			
+
+			}
 		}
 		return null;
-		
+
 	}
 
 


### PR DESCRIPTION
# Summary
- Query by tag, tag property
- "Not Equal" predicate
## Tag Property
- Added "tag" value to the hash describing an element (`.../query/ViewMapper.java`)
- Added `getTagForView` to get the view's tag (if any).
- Support predicates for "tag" property in queries

Can be used as an alternative to an ID. Since anything can be a tag in Android, it can be utilized to be similar to `accessbilityIdentifier` in iOS.

Android allows assigning multiple tags to the view and get them by the index using `getTag(int index)`, but this implementation depends on "default" tag accessible via `getTag()`.
## Not Equal Predicate

Added `NOTEQUAL` predicate support (`.../query/ast/ComparisonOperator.java` and `.../query/ast/UIQueryASTPredicate.java`) to enable queries with "!=" and "<>" comparisons.
Modified `UIQuery.g` for the same.
## Formatting
- Remove trailing spaces in all touched files
- Fix blank lines (remove obsolete spaces) in all touched files
