### PR TITLE
Add a couple of actions to the removed_actions.txt

### DIFF
--- a/ruby-gem/lib/calabash-android/removed_actions.txt
+++ b/ruby-gem/lib/calabash-android/removed_actions.txt
@@ -8,6 +8,7 @@ wait
 wait_for_text
 wait_for_no_progress_bars
 press_button_with_text
+press_button_number
 wait_for_view_by_id
 toggle_numbered_checkbox
 has_view
@@ -31,3 +32,5 @@ press_long_on_text_and_select_with_index
 press_long_on_text_and_select_with_text
 assert_text
 assert_text_in_textview
+long_press_on_view_by_id
+press_long_on_text_and_select_with_id


### PR DESCRIPTION
I've just went over all the commits of this branch and noticed a couple of missing actions from the `removed_actions.txt`:
- `press_button_number`
- `long_press_on_view_by_id`
- `press_long_on_text_and_select_with_id`

Added them to the file.
