### PR TITLE
fixed an issue the count of devices was wrong when `adb devices` outputs...

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -441,8 +441,8 @@ module Operations
 
     def connected_devices
       lines = `#{Env.adb_path} devices`.split("\n")
-      lines.shift
-      lines.collect { |l| l.split("\t").first}
+      start_index = lines.index{ |x| x =~ /List of devices attached/ } + 1
+      lines[start_index..-1].collect { |l| l.split("\t").first }
     end
 
     def wake_up


### PR DESCRIPTION
...:

```
    * daemon not running. starting it now on port 5037 *
    * * daemon started successfully
    List of devices attached
```
