### PR TITLE
Updated rubyzip dependency, and removed xamarin-test-cloud dependency.

### DIFF
--- a/ruby-gem/Gemfile.lock
+++ b/ruby-gem/Gemfile.lock
@@ -1,53 +1,40 @@
 PATH
   remote: .
   specs:
-    calabash-android (0.4.22.pre1)
+    calabash-android (0.5.0.pre2)
       awesome_print
       cucumber
       escape (~> 0.0.4)
       httpclient (~> 2.3.2)
       json
       retriable (~> 1.3.3.1)
-      rubyzip (~> 0.9.9)
+      rubyzip (~> 1.1)
       slowhandcuke
-      xamarin-test-cloud (>= 0.9.23)
 
 GEM
   remote: http://rubygems.org/
   specs:
     awesome_print (1.2.0)
     builder (3.2.2)
-    cucumber (1.3.11)
+    cucumber (1.3.15)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.0.2)
+      multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
     escape (0.0.4)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     httpclient (2.3.4.1)
     json (1.8.1)
-    mime-types (1.25.1)
-    multi_json (1.9.0)
-    multi_test (0.0.3)
+    multi_json (1.10.1)
+    multi_test (0.1.1)
     rake (10.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
     retriable (1.3.3.1)
-    rubyzip (0.9.9)
+    rubyzip (1.1.6)
     slowhandcuke (0.0.3)
       cucumber
-    thor (0.18.1)
-    xamarin-test-cloud (0.9.29)
-      bundler (>= 1.3.0, < 2.0)
-      json
-      mime-types (< 2.0)
-      rest-client (~> 1.6.7)
-      retriable (~> 1.3.3.1)
-      rubyzip (~> 0.9.9)
-      thor (>= 0.18.1)
 
 PLATFORMS
   ruby

--- a/ruby-gem/bin/calabash-android-build.rb
+++ b/ruby-gem/bin/calabash-android-build.rb
@@ -50,8 +50,8 @@ def calabash_build(app)
         raise "Could not create dummy.apk"
       end
 
-      Zip::ZipFile.new("dummy.apk").extract("AndroidManifest.xml","customAndroidManifest.xml")
-      Zip::ZipFile.open("TestServer.apk") do |zip_file|
+      Zip::File.new("dummy.apk").extract("AndroidManifest.xml","customAndroidManifest.xml")
+      Zip::File.open("TestServer.apk") do |zip_file|
         zip_file.add("AndroidManifest.xml", "customAndroidManifest.xml")
       end
     end

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency( "json" )
   s.add_dependency( "retriable", "~> 1.3.3.1" )
   s.add_dependency( "slowhandcuke" )
-  s.add_dependency( "rubyzip", "~> 0.9.9" )
+  s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print" )
   s.add_dependency( 'httpclient', '~> 2.3.2')
-  s.add_dependency( 'xamarin-test-cloud', '>= 0.9.23')
   s.add_dependency( 'escape', '~> 0.0.4')
 end

--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -1,5 +1,5 @@
 require "stringio"
-require 'zip/zip'
+require 'zip'
 require 'tempfile'
 require 'escape'
 require 'rbconfig'
@@ -83,7 +83,7 @@ def fingerprint_from_apk(app_path)
     Dir.chdir(tmp_dir) do
       FileUtils.cp(app_path, "app.apk")
       FileUtils.mkdir("META-INF")
-      Zip::ZipFile.foreach("app.apk") do |z|
+      Zip::File.foreach("app.apk") do |z|
         z.extract if /^META-INF\/\w+.(RSA|rsa)/ =~ z.name
       end
       rsa_files = Dir["#{tmp_dir}/META-INF/*"]


### PR DESCRIPTION
Updated `rubyzip` dependency, so that we use a more recent version. `rubyzip` 1.0 breaks the interface, so (simple) code changes were required.

I've successfully uploaded a test with the locally built `calabash-android` gem, rebuilt a test server, etc., so it seems like everything's OK.

There's a slight complication: `calabash-android` depended on the `xamarin-test-cloud` gem, which again depends (currently) on `rubyzip` 0.9.9. I agreed with @krukow that the best solution is to remove the dependency from `calabash-android` to `xamarin-test-cloud`, and then create a new gem, simply called `calabash`, which depends on `calabash-android`, `calabash-cucumber` (a.k.a. calabash-ios), and `xamarin-test-cloud`. We'll also update the `xamarin-test-cloud` gem to use a newer `rubyzip`.

@TobiasRoikjer or @jonasmaturana will you please have a look at this PR and merge if it looks OK to you? I think you should be in the loop. After `calabash-android` 0.5.0 is released, we'll release an updated `xamarin-test-cloud` gem.
