### PR TITLE
Don't force Class init by querying

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/Query.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/Query.java
@@ -117,7 +117,7 @@ public class Query {
 		switch (step.getType()) {
 		case UIQueryParser.QUALIFIED_NAME:
 			try {
-				return new UIQueryASTClassName(Class.forName(step.getText()));
+				return new UIQueryASTClassName(Class.forName(step.getText(), false, Query.class.getClassLoader()));
 			} catch (ClassNotFoundException e) {
 				return new UIQueryASTClassName((String)null);
 			}


### PR DESCRIPTION
The call to Class.forName(step.getText()) can cause side effects because of static initializers of unloaded classes:

https://github.com/calabash/calabash-android/blob/67abb9cd43bb6fdf8f91cb76c64ac3eb96ca2c4b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/Query.java#L120

I think we can solve the issue by using 
Class.forName(step.getText(), false, this.getClass().getClassLoader())
If not we should be able to ask the current classloader and short circuit if class is not yet loaded

cc @kasperlanger @TobiasRoikjer 