### PR TITLE
Fixes 'environment' typo in bin help text

### DIFF
--- a/ruby-gem/bin/calabash-android-helpers.rb
+++ b/ruby-gem/bin/calabash-android-helpers.rb
@@ -24,7 +24,7 @@ def print_usage
     build <apk>
       builds the test server that will be used when testing the app.
     run <apk>
-      runs Cucumber in the current folder with the enviroment needed.
+      runs Cucumber in the current folder with the environment needed.
     version
       prints the gem version
 


### PR DESCRIPTION
I came across this while doing some other work.

I would have pushed right to master, but I don't know the rest of you feel about doing that.
