### PR TITLE
Correct usage of commitText method. 

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/ClearText.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/ClearText.java
@@ -28,7 +28,7 @@ public class ClearText implements Action {
             @Override
             public void run() {
                 connection.setSelection(0, editable.length());
-                connection.commitText("", 0);
+                connection.commitText("", 1);
                 latch.countDown();
             }
         });

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -31,7 +31,7 @@ public class KeyboardEnterText implements Action {
             @Override
             public void run() {
                 for (char c : textToEnter.toCharArray()) {
-                    inputConnection.commitText(Character.toString(c), 0);
+                    inputConnection.commitText(Character.toString(c), 1);
                 }
             }
         });


### PR DESCRIPTION
Correct usage of commitText method. Placing cursor after inserted text as it should be.
Quote from documentation:

> The new cursor position around the text, in Java characters. If > 0, this is relative to the end of the text - 1; if <= 0, this is relative to the start of the text. So a value of 1 will always advance the cursor to the position after the full text being inserted. Note that this means you can't position the cursor within the text, because the editor can make modifications to the text you are providing so it is not possible to correctly specify locations there.
