### PR TITLE
Use existing default target

### DIFF
--- a/ruby-gem/test-server/build.xml
+++ b/ruby-gem/test-server/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project name="" default="test" basedir=".">
+<project name="" default="package" basedir=".">
     <description>
       Bits and pieces plucked out of $ANDROID_HOME/tools/ant/build.xml
     </description>


### PR DESCRIPTION
This fixes the default target, when ant is called without any argument.
