### PR TITLE
Fix undefined step : set date to DatePicker with index

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/date_picker_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/date_picker_steps.rb
@@ -1,5 +1,5 @@
 
-Given /^I set the date to "(\d\d-\d\d-\d\d\d\d)" on DatePicker with index ([^\"]*)$/ do |date, index|
+Given /^I set the date to "(\d\d-\d\d-\d\d\d\d)" on DatePicker with index "([^\"]*)"$/ do |date, index|
   set_date("android.widget.DatePicker index:#{index.to_i-1}", date)
 end
 


### PR DESCRIPTION
Since last change, the step "I set the date to ... on DatePicker with index ..." would give an undefined. This corrects it and works as before, setting the right date to the chosen DatePicker.