### PR TITLE
Update httpclient fix keepalivedisconnected

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print", '~> 1.2.0')
-  s.add_dependency( 'httpclient', '~> 2.6.0')
+  s.add_dependency( 'httpclient', '>= 2.3.2', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')
 
   s.add_development_dependency( 'rake', '~> 10.3' )

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print", '~> 1.2.0')
-  s.add_dependency( 'httpclient', '~> 2.3.2')
+  s.add_dependency( 'httpclient', '~> 2.6.0')
   s.add_dependency( 'escape', '~> 0.0.4')
 
   s.add_development_dependency( 'rake', '~> 10.3' )

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,5 +1,5 @@
 module Calabash
   module Android
-    VERSION = "0.5.6.pre1"
+    VERSION = "0.5.6.pre2"
   end
 end


### PR DESCRIPTION
Dependency httpclient version 2.6.x fixes two important issues:

https://github.com/nahi/httpclient/issues/84
https://github.com/nahi/httpclient/issues/185

Let's be less strict in httpclient versions supported to allow this update. But let's not force a version which would break compat with x-platform projects that don't update Calabash iOS.