### PR TITLE
Rescue 'awesome_print' LoadError in irbrc; don't fail silently

### DIFF
--- a/ruby-gem/irbrc
+++ b/ruby-gem/irbrc
@@ -1,7 +1,26 @@
 require 'rubygems'
 require 'irb/completion'
 require 'irb/ext/save-history'
-require 'awesome_print'
+
+begin
+  require 'awesome_print'
+rescue LoadError => e
+  msg = ["Caught a LoadError: could not load 'awesome_print'",
+         "#{e}",
+         '',
+         'Use bundler (recommended) or uninstall awesome_print.',
+         '',
+         '# Use bundler (recommended)',
+         '$ bundle update',
+         '$ bundle exec calabash-android console <path to apk>',
+         '',
+         '# Uninstall',
+         '$ gem update --system',
+         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+  puts msg
+  exit(1)
+end
+
 AwesomePrint.irb!
 
 ARGV.concat [ "--readline",


### PR DESCRIPTION
#### Motivation

`LoadError`s generated by `require` statements in `.irbrc` generate no output; they fail silently.  To the casual user, the irb appears to have loaded correctly, but in fact the evaluation of the .irbrc stops at the first exception.

We've been handling a lot of support questions about "Why aren't the calabash methods loaded in the console?".  Most of these have been because of incompatible versions of `awesome_print`.
