### PR TITLE
Match the retriable dependency with test-cloud

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency( "cucumber", '~> 1.3.17' )
   s.add_dependency( "json", '~> 1.8' )
-  s.add_dependency( "retriable", "~> 1.3.3.1" )
+  s.add_dependency( 'retriable', '>= 1.3.3.1', '< 2.0' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print", '~> 1.2')


### PR DESCRIPTION
#### Motivation

We should try to match the test-cloud gem retriable dependency.
