### PR TITLE
Update CalabashChromeClient.java

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/webview/CalabashChromeClient.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/webview/CalabashChromeClient.java
@@ -108,7 +108,7 @@ public class CalabashChromeClient extends WebChromeClient {
 
     private boolean superClassEquals(Class clazz, String className) {
         do {
-            if (clazz.getCanonicalName().equals(className)) {
+            if (className.equals(clazz.getCanonicalName())) {
                 return true;
             }
         } while((clazz = clazz.getSuperclass()) != Object.class);


### PR DESCRIPTION
This NPE happens because getCanonicalName() returns null for anonymous inner classes. These are fairly common, for example the Facebook SDK uses one for their webview login.

Fixed by simply swapping the operands on the comparison.