### PR TITLE
Fix calabash/calabash-android#546 by following Robotium's suggestion

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/com/jayway/android/robotium/solo/SoloEnhanced.java
@@ -13,6 +13,12 @@ public class SoloEnhanced extends Solo {
 		super(instrumentation, activity);
 		this.mapViewUtils = new MapViewUtils(instrumentation, viewFetcher, sleeper, waiter);
 	}
+
+	public SoloEnhanced(Instrumentation instrumentation) {
+		super(instrumentation);
+		this.mapViewUtils = new MapViewUtils(instrumentation, viewFetcher, sleeper, waiter);
+	}
+
     public ActivityUtils getActivityUtils() {
         return activityUtils;
     }

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/InstrumentationBackend.java
@@ -135,7 +135,7 @@ public class InstrumentationBackend extends ActivityInstrumentationTestCase2<Act
             }
         }
         if (activity != null) {
-            solo = new SoloEnhanced(getInstrumentation(), activity);
+            solo = new SoloEnhanced(getInstrumentation());
             setActivity(activity);
 
             viewFetcher = new PublicViewFetcher(solo.getActivityUtils());


### PR DESCRIPTION
The workaround proposed by `renasr...` at <https://code.google.com/p/robotium/issues/detail?id=179#c6>
appears to work correctly and solves the mismatch bug.

The problem occurs when `activity` has already launched a subsequent activity and is itself no longer active.  By passing the activity to the `Solo` constructor, it loses the ability to track which activity is active.  The proposed workaround allows Solo/Android to get the active activity as needed, so the problem does not occur.