### PR TITLE
Fix "invalid byte sequence in US-ASCII" error

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -40,7 +40,7 @@ module Calabash module Android
     end
 
     def current_activity
-      `#{default_device.adb_command} shell dumpsys window windows`.each_line.grep(/mFocusedApp.+[\.\/]([^.\s\/\}]+)/){$1}.first
+      `#{default_device.adb_command} shell dumpsys window windows`.force_encoding('UTF-8').each_line.grep(/mFocusedApp.+[\.\/]([^.\s\/\}]+)/){$1}.first
     end
 
     def log(message)


### PR DESCRIPTION
Some devices may respond with Unicode characters in the `adb shell dumpsys`
output, which causes comparison to string literals to fail with:

    invalid byte sequence in US-ASCII (ArgumentError) (RuntimeError)

Using `String#force_encoding(UTF-8)` fixes that.