### PR TITLE
Fixed "l10key" typo...

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/l10n_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/l10n_steps.rb
@@ -1,17 +1,17 @@
-Then /^I press text of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key)
+Then /^I press text of translated l10nkey (\d+)$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey)
 end
 
-Then /^I press button of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'button')
+Then /^I press button of translated l10nkey (\d+)$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'button')
 end
 
-Then /^I press menu item of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'menu_item')
+Then /^I press menu item of translated l10nkey (\d+)$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'menu_item')
 end
 
-Then /^I press toggle button of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'toggle_button')
+Then /^I press toggle button of translated l10nkey (\d+)$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'toggle_button')
 end
 
 Then /^I wait for the translated "([^\"]*)" l10nkey to appear$/ do |l10nkey|


### PR DESCRIPTION
In one definition, `l10nkey` is used correctly.  In the rest, there is a typo ,and the key is named `l10key` instead.