### PR TITLE
Fixed regexp for l10nkey definitions....

### DIFF
--- a/ruby-gem/lib/calabash-android/canned_steps.md
+++ b/ruby-gem/lib/calabash-android/canned_steps.md
@@ -208,16 +208,16 @@ To use a set of concrete GPS cordinates
 Internationalization
 --------------------
 
-	Then /^I press text of translated l10key (\d+)$/ 
+	Then /^I press text of translated l10key "([^\"]*)"$/ 
 Simulates that the user pressed the text of the l10nkey.	
 
-	Then /^I press button of translated l10key (\d+)$/
+	Then /^I press button of translated l10key "([^\"]*)"$/
 Simulates that the user pressed the button with the label text of the l10nkey.
 
-	Then /^I press menu item of translated l10key (\d+)$/
+	Then /^I press menu item of translated l10key "([^\"]*)"$/
 Simulates that the user pressed the menu item with the label text of the l10nkey.
 
-	Then /^I press toggle button of translated l10key (\d+)$/ 
+	Then /^I press toggle button of translated l10key "([^\"]*)"$/ 
 Simulates that the user pressed the toggle button with the label text of the l10nkey.	
 
 	Then /^I wait for the translated "([^\"]*)" l10nkey to appear$/ 


### PR DESCRIPTION
In continuing to work with these in my own tests, I see that the regexp only works with numeric l10n keys.  It would be more useful if it worked with non-quote characters as in the definition of:

`I wait for the translated "key" l10nkey to appear`

Fixing the docs here, will also submit a pull request for the code.