### PR TITLE
Feature/enter append text

### DIFF
--- a/ruby-gem/lib/calabash-android/text_helpers.rb
+++ b/ruby-gem/lib/calabash-android/text_helpers.rb
@@ -1,6 +1,18 @@
 module Calabash
   module Android
     module TextHelpers
+      def selection_start
+        'SELECTION_START'
+      end
+
+      def selection_end
+        'SELECTION_END'
+      end
+
+      def selection_all
+        'SELECTION_ALL'
+      end
+
       def has_text?(text)
         !query("* {text CONTAINS[c] '#{text}'}").empty?
       end
@@ -22,9 +34,13 @@ module Calabash
       def enter_text(uiquery, text, options = {})
         tap_when_element_exists(uiquery, options)
 
-        options.merge!({action: lambda { keyboard_enter_text(text, options);}})
+        wait_for({timeout: 5, timeout_message: "Timeout waiting for element to gain focus"}) do
+          query(uiquery, :isFocused).first
+        end
 
-        when_element_exists("#{uiquery} isFocused:true", options)
+        perform_action("set_selection", selection_end)
+
+        keyboard_enter_text(text, options)
 
       end
 

--- a/ruby-gem/lib/calabash-android/text_helpers.rb
+++ b/ruby-gem/lib/calabash-android/text_helpers.rb
@@ -21,8 +21,11 @@ module Calabash
 
       def enter_text(uiquery, text, options = {})
         tap_when_element_exists(uiquery, options)
-        sleep 0.5
-        keyboard_enter_text(text, options)
+
+        options.merge!({action: lambda { keyboard_enter_text(text, options);}})
+
+        when_element_exists("#{uiquery} isFocused:true", options)
+
       end
 
       def clear_text_in(query_string, options={})

--- a/ruby-gem/lib/calabash-android/text_helpers.rb
+++ b/ruby-gem/lib/calabash-android/text_helpers.rb
@@ -1,17 +1,9 @@
 module Calabash
   module Android
     module TextHelpers
-      def selection_start
-        'SELECTION_START'
-      end
 
-      def selection_end
-        'SELECTION_END'
-      end
-
-      def selection_all
-        'SELECTION_ALL'
-      end
+      #keyword to indicate the end of a string (which may be of unknown length)
+      SELECTION_END = 'SELECTION_END'
 
       def has_text?(text)
         !query("* {text CONTAINS[c] '#{text}'}").empty?
@@ -34,11 +26,12 @@ module Calabash
       def enter_text(uiquery, text, options = {})
         tap_when_element_exists(uiquery, options)
 
-        wait_for({timeout: 5, timeout_message: "Timeout waiting for element to gain focus"}) do
-          query(uiquery, :isFocused).first
+        wait_for({timeout: 5, timeout_message: 'Timeout waiting for element to gain focus'}) do
+          query(uiquery, :isFocused)
         end
 
-        perform_action("set_selection", selection_end)
+        #set selection to the end of the string
+        perform_action('set_selection', SELECTION_END, SELECTION_END)
 
         keyboard_enter_text(text, options)
 

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -15,7 +15,7 @@ public class SetSelection implements Action {
     private static final String SELECTION_START = "SELECTION_START";
     private static final String SELECTION_END   = "SELECTION_END";
     private static final String SELECTION_ALL   = "SELECTION_ALL";
-    
+
     private static final String USAGE           = "This action takes 1 or 2 arguments:\n"
                                                     + "(\"SELECTION_START\") |  (\"SELECTION_END\") | (\"SELECTION_ALL\") |\n" 
                                                     + " ([int] position) | ([int] position, [int] length)";
@@ -28,12 +28,12 @@ public class SetSelection implements Action {
 
         final BaseInputConnection connection = getConnection();
         if(connection == null) {
-            return Result.failedResult("Unable to clear text, no element has focus");
+            return Result.failedResult("Unable to set selection, no element has focus");
         }
 
         final Editable editable = connection.getEditable();
         if(editable == null) {
-            return Result.failedResult("Unable to clear text, not editable");
+            return Result.failedResult("Unable to set selection, not editable");
         }
 
         final int textLength = editable.length();

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -51,18 +51,9 @@ public class SetSelection implements Action {
                 } else {
                     setSelection(connection, Integer.parseInt(args[0]), Integer.parseInt(args[1]));
                 }
-                latch.countDown();
             }
         });
-
-        try {
-            latch.await(10, TimeUnit.SECONDS);
-            return Result.successResult();
-        } catch (InterruptedException e) {
-            Result result = Result.fromThrowable(e);
-            result.setMessage("Timeout while trying to set selection");
-            return result;
-        }
+        return Result.successResult();
     }
 
     private void setSelection(BaseInputConnection connection, int position) {

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -1,0 +1,102 @@
+package sh.calaba.instrumentationbackend.actions.text;
+
+import android.text.Editable;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.InputConnection;
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
+import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.actions.Action;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SetSelection implements Action {
+
+    private static final String SELECTION_START = "SELECTION_START";
+    private static final String SELECTION_END   = "SELECTION_END";
+    private static final String SELECTION_ALL   = "SELECTION_ALL";
+    
+    private static final String USAGE           = "This action takes 1 or 2 arguments:\n"
+                                                    + "(\"SELECTION_START\") |  (\"SELECTION_END\") | (\"SELECTION_ALL\") |\n" 
+                                                    + " ([int] position) | ([int] position, [int] length)";
+
+    @Override
+    public Result execute(final String... args) {
+        if (args.length == 0 || args.length > 2) {
+            return Result.failedResult(USAGE);
+        } 
+
+        final BaseInputConnection connection = getConnection();
+        if(connection == null) {
+            return Result.failedResult("Unable to clear text, no element has focus");
+        }
+
+        final Editable editable = connection.getEditable();
+        if(editable == null) {
+            return Result.failedResult("Unable to clear text, not editable");
+        }
+
+        final int textLength = editable.length();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        InstrumentationBackend.solo.runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                if (args.length == 1) {
+                    String arg1 = args[0];
+                    if (arg1.equals(SELECTION_START)) { selectStart(connection); }
+                    else if (arg1.equals(SELECTION_END)) { selectEnd(connection, textLength); }
+                    else if (arg1.equals(SELECTION_ALL)) { selectAll(connection, textLength); }
+                    else { setSelection(connection, Integer.parseInt(arg1)); }
+                } else {
+                    setSelection(connection, Integer.parseInt(args[0]), Integer.parseInt(args[1]));
+                }
+                latch.countDown();
+            }
+        });
+
+        try {
+            latch.await(10, TimeUnit.SECONDS);
+            return Result.successResult();
+        } catch (InterruptedException e) {
+            Result result = Result.fromThrowable(e);
+            result.setMessage("Timeout while trying to set selection");
+            return result;
+        }
+    }
+
+    private void setSelection(BaseInputConnection connection, int position) {
+        connection.setSelection(position, position);
+    }
+
+    private void setSelection(BaseInputConnection connection, int position, int length) {
+        connection.setSelection(position, length);
+    }
+
+    private void selectAll(BaseInputConnection connection, int textLength) {
+        connection.setSelection(0, textLength);
+    }
+
+    private void selectStart(BaseInputConnection connection) {
+        setSelection(connection, 0);
+    }
+
+    private void selectEnd(BaseInputConnection connection, int textLength) {
+        setSelection(connection, textLength);
+    }
+
+    private BaseInputConnection getConnection() {
+        InputConnection inputConnection = InfoMethodUtil.getInputConnection();
+        if (inputConnection instanceof BaseInputConnection) {
+            return (BaseInputConnection) inputConnection;
+        } else {
+            System.out.println("InputConnection is not an instance of BaseInputConnection. (" + (inputConnection == null ? "null" : inputConnection.getClass().toString()) + ")");
+            return null;
+        }
+    }
+
+    @Override
+    public String key() {
+        return "set_selection";
+    }
+}


### PR DESCRIPTION
Completes #583 

`enter_text` consistently appends text (previous behavior inconsistently results in appending the new text, inserting the new text inside of an existing string, or replacing an existing string with the new string).

- Added new action in calabash server for setting text (works similar to `lseek()`)
- Use `wait_for` to ensure an element gains focus before attempting to enter text
- Changed implementation of `enter_text` to set cursor position to the end before entering text