### PR TITLE
Retrieve Jacoco coverage

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -3,7 +3,7 @@ require 'zip'
 require 'tempfile'
 require 'escape'
 require 'rbconfig'
-require 'calabash-android/java_keystore'
+require_relative 'java_keystore'
 
 def package_name(app)
   unless File.exist?(app)

--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/HttpServer.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/HttpServer.java
@@ -9,6 +9,8 @@ import java.io.StringWriter;
 import java.lang.InterruptedException;
 import java.lang.Override;
 import java.lang.Runnable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -354,6 +356,28 @@ public class HttpServer extends NanoHTTPD {
 
 		} else if (uri.endsWith("/ready")) {
 			return new Response(HTTP_OK, MIME_HTML, Boolean.toString(ready));
+
+		} else if (uri.endsWith("/coverage")) {
+			try {
+				// Use reflection like Android InstrumentationTestRunner for now.
+				ClassLoader classLoader = InstrumentationBackend.instrumentation.getTargetContext().getClassLoader();
+				Class<?> RTClass = classLoader.loadClass("org.jacoco.agent.rt.RT");
+				Method getAgentMethod = RTClass.getMethod("getAgent");
+				Object agent = getAgentMethod.invoke(null);
+				Class<?> IAgentClass = classLoader.loadClass("org.jacoco.agent.rt.IAgent");
+				Method dumpCoverageMethod = IAgentClass.getMethod("getExecutionData", boolean.class);
+				byte[] executionData = (byte[])dumpCoverageMethod.invoke(agent, true);
+				return new NanoHTTPD.Response(HTTP_OK, "application/data",
+						new ByteArrayInputStream(executionData));
+			}
+			catch (Exception e) {
+				StringWriter sw = new StringWriter();
+				PrintWriter pw = new PrintWriter(sw);
+				e.printStackTrace(pw);
+				System.out.println(sw.toString());
+				return new NanoHTTPD.Response(HTTP_INTERNALERROR, null,
+						sw.toString());
+			}
 
 		} else if (uri.endsWith("/screenshot")) {
 			try {


### PR DESCRIPTION
Permits retrieval of coverage information incrementally during testing, into a directory specified by the env-var COVERAGE_DIR.

Uses reflection to avoid version clash between Calabash and the Android plug-in over precisely which Jacoco should be in use.

Generation of a fully instrumented app and subsequent report generation is based on https://code.google.com/p/android/issues/detail?id=76373#c11 which outlines changes to the user's gradle build. That article notwithstanding, it appears sufficient to set `android{ buildTypes{ release{ testCoverageEnabled=true } } }` in libraries, or arrange to link against debug+instrumented libraries with `android{ defaultPublishConfig "flavor1Debug" }`
