### PR TITLE
Actions: Get SDK Version

### DIFF
--- a/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/version/AndroidSDKVersion.java
+++ b/ruby-gem/test-server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/version/AndroidSDKVersion.java
@@ -1,0 +1,21 @@
+ package sh.calaba.instrumentationbackend.actions.version;
+
+ import sh.calaba.instrumentationbackend.Result;
+ import sh.calaba.instrumentationbackend.actions.Action;
+ import android.os.Build;
+
+
+public class AndroidSDKVersion implements Action {
+    public static final int VERSION = Build.VERSION.SDK_INT;
+
+    @Override
+    public Result execute(String... args) {
+        return new Result(true, Integer.toString(VERSION));
+    }
+
+    @Override
+    public String key() {
+        return "android_sdk_version";
+    }
+
+}


### PR DESCRIPTION
Gets android SDK version. Only works on android 1.6 and later (I don’t think that’s a problem for us). 
