### PR TITLE
Gem: allow cucumber 2.0

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = "calabash-android"
   s.require_paths = ["lib"]
 
-  s.add_dependency( "cucumber", '~> 1.3.17' )
+  s.add_dependency( "cucumber", '>= 1.3.17', '< 3.0' )
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( 'retriable', '>= 1.3.3.1', '< 1.5')
   s.add_dependency( "slowhandcuke", '~> 0.0.3')


### PR DESCRIPTION
### Motivation

There is no reason not to allow Cucumber 2.0

https://github.com/calabash/calabash-android/issues/614