### PR TITLE
Fixing l10nkey to allow for non-numeric keys

### DIFF
--- a/ruby-gem/lib/calabash-android/canned_steps.md
+++ b/ruby-gem/lib/calabash-android/canned_steps.md
@@ -208,19 +208,19 @@ To use a set of concrete GPS cordinates
 Internationalization
 --------------------
 
-	Then /^I press text of translated l10key (\d+)$/ 
+	Then /^I press text of translated l10nkey "?([^\"]*)"?$/ 
 Simulates that the user pressed the text of the l10nkey.	
 
-	Then /^I press button of translated l10key (\d+)$/
+	Then /^I press button of translated l10nkey "?([^\"]*)"?$/
 Simulates that the user pressed the button with the label text of the l10nkey.
 
-	Then /^I press menu item of translated l10key (\d+)$/
+	Then /^I press menu item of translated l10nkey "?([^\"]*)"?$/
 Simulates that the user pressed the menu item with the label text of the l10nkey.
 
-	Then /^I press toggle button of translated l10key (\d+)$/ 
+	Then /^I press toggle button of translated l10nkey "?([^\"]*)?"$/ 
 Simulates that the user pressed the toggle button with the label text of the l10nkey.	
 
-	Then /^I wait for the translated "([^\"]*)" l10nkey to appear$/ 
+	Then /^I wait for the translated "?([^\"]*)"? l10nkey to appear$/ 
 Waits until the text of the translated l10nkey is displayed.
 
 Note: you can assert or press interface elements using [Android's String resources](http://developer.android.com/reference/android/R.string.html) by passing a package in a custom step:

--- a/ruby-gem/lib/calabash-android/steps/l10n_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/l10n_steps.rb
@@ -1,19 +1,19 @@
-Then /^I press text of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key)
+Then /^I press text of translated l10n?key "?([^\"]*)"?$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey)
 end
 
-Then /^I press button of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'button')
+Then /^I press button of translated l10n?key "?([^\"]*)"?$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'button')
 end
 
-Then /^I press menu item of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'menu_item')
+Then /^I press menu item of translated l10n?key "?([^\"]*)"?$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'menu_item')
 end
 
-Then /^I press toggle button of translated l10key (\d+)$/ do |l10key|
-  perform_action('press_l10n_element', l10key,'toggle_button')
+Then /^I press toggle button of translated l10n?key "?([^\"]*)"?$/ do |l10nkey|
+  perform_action('press_l10n_element', l10nkey,'toggle_button')
 end
 
-Then /^I wait for the translated "([^\"]*)" l10nkey to appear$/ do |l10nkey|
+Then /^I wait for the translated "?([^\"]*)"? l10n?key to appear$/ do |l10nkey|
   perform_action('wait_for_l10n_element', l10nkey)
 end


### PR DESCRIPTION
This adds support for non-numeric l10nkeys, while keeping in place compatibility with the old definitions