### PR TITLE
Gem: relax cucumber dependency

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = "calabash-android"
   s.require_paths = ["lib"]
 
-  s.add_dependency( "cucumber", '~> 1.3.17' )
+  s.add_dependency( "cucumber" )
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( 'retriable', '>= 1.3.3.1', '< 1.5')
   s.add_dependency( "slowhandcuke", '~> 0.0.3')


### PR DESCRIPTION
### Motivation

There is no reason _not_ to allow Cucumber 2.0.

@TobiasRoikjer We talked about removing the dependency all together, but that would require that existing users update their Gemfiles.  I am not ready to go through the process of documenting this.

This is a good first step.

@sapieneptus @krukow @jraczak

This change will be part of Calabash iOS 0.17.

https://github.com/calabash/calabash-ios/pull/904 - merged.