### PR TITLE
Gem: only include necessary files in the gem

### DIFF
--- a/bin/ci/travis/run.sh
+++ b/bin/ci/travis/run.sh
@@ -2,5 +2,9 @@
 
 cd ruby-gem
 bundle update
+
+touch lib/calabash-android/lib/TestServer.apk
+gem build calabash-android.gemspec
+
 bundle exec rake unit
 

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -12,9 +12,20 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/calabash"
   s.summary     = %q{Client for calabash-android for automated functional testing on Android}
   s.description = %q{calabash-android drives tests for native  and hybrid Android apps. }
-  s.files         = `git ls-files | grep -v "test-server/instrumentation-backend"`.split("\n") +  ["lib/calabash-android/lib/AndroidManifest.xml","lib/calabash-android/lib/TestServer.apk"]
   s.executables   = "calabash-android"
   s.require_paths = ["lib"]
+  s.files         = lambda do
+      # This should be in lib/calabash-android somewhere
+      ["irbrc"] +
+      Dir.glob("bin/**/*.rb") + ["bin/calabash-android"] +
+      Dir.glob("test-server/calabash-js/src/*.js") +
+      Dir.glob("lib/**/*.jar") +
+      Dir.glob("features-skeleton/**/*.*") +
+      ["epl-v10.html", "LICENSE"] +
+      ["lib/calabash-android/lib/TestServer.apk",
+       "test-server/AndroidManifest.xml",
+       "test-server/build.xml"]
+  end.call
 
   s.add_dependency( "cucumber" )
   s.add_dependency( "json", '~> 1.8' )


### PR DESCRIPTION
### Motivation

Resolves **Gem contains many unnecessary files** #651

To the reviewer, I left out these files:

* ruby-gems/.calabash_settings
* ruby-gems/lib/calabash-android/canned_steps.md
* ruby-gems/lib/calabash-android/removed_actions.txt

I think Tobias is the obvious reviewer.

