### PR TITLE
Env: port run-loop enviroment.rb

### DIFF
--- a/ruby-gem/lib/calabash-android.rb
+++ b/ruby-gem/lib/calabash-android.rb
@@ -1,4 +1,5 @@
 require 'calabash-android/defaults'
+require 'calabash-android/environment'
 require 'calabash-android/operations'
 require 'calabash-android/version'
 require 'calabash-android/abase'

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -1,7 +1,11 @@
 module Calabash
   module Android
-
     class Environment
+
+      # Returns true if running on Windows
+      def self.windows?
+        RbConfig::CONFIG['host_os'][/mswin|mingw|cygwin/, 0] != nil
+      end
 
       # Returns the user home directory
       def self.user_home_directory
@@ -10,8 +14,20 @@ module Calabash
           FileUtils.mkdir_p(home)
           home
         else
-          require 'etc'
-          Etc.getpwuid.dir
+          if self.windows?
+            # http://stackoverflow.com/questions/4190930/cross-platform-means-of-getting-users-home-directory-in-ruby
+            home = ENV["HOME"] || ENV["USERPROFILE"]
+          else
+            require "etc"
+            home = Etc.getpwuid.dir
+          end
+
+          unless File.exist?(home)
+            home = File.join("./", "tmp", "home")
+            FileUtils.mkdir_p(home)
+          end
+
+          home
         end
       end
 

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -68,23 +68,6 @@ module Calabash
         ].any?
       end
 
-      # !@visibility private
-      def self.with_debugging(debug, &block)
-        if debug
-          original_value = ENV['DEBUG']
-
-          begin
-            ENV['DEBUG'] = '1'
-            block.call
-          ensure
-            ENV['DEBUG'] = original_value
-          end
-
-        else
-          block.call
-        end
-      end
-
       private
 
       # !@visibility private

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -57,6 +57,14 @@ module Calabash
         !!value && value != ''
       end
 
+      # Returns true if running in Teamcity
+      #
+      # Checks the value of GITLAB_CI
+      def self.gitlab?
+        value = ENV["GITLAB_CI"]
+        !!value && value != ''
+      end
+
       # Returns true if running in a CI environment
       def self.ci?
         [
@@ -64,7 +72,8 @@ module Calabash
           self.travis?,
           self.jenkins?,
           self.circle_ci?,
-          self.teamcity?
+          self.teamcity?,
+          self.gitlab?
         ].any?
       end
 

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -1,0 +1,98 @@
+module Calabash
+  module Android
+
+    class Environment
+
+      # Returns the user home directory
+      def self.user_home_directory
+        if self.xtc?
+          home = File.join("./", "tmp", "home")
+          FileUtils.mkdir_p(home)
+          home
+        else
+          require 'etc'
+          Etc.getpwuid.dir
+        end
+      end
+
+      # Returns true if debugging is enabled.
+      def self.debug?
+        ENV['DEBUG'] == '1'
+      end
+
+      # Returns true if we are running on the XTC
+      def self.xtc?
+        ENV['XAMARIN_TEST_CLOUD'] == '1'
+      end
+
+      # Returns true if running in Jenkins CI
+      #
+      # Checks the value of JENKINS_HOME
+      def self.jenkins?
+        value = ENV["JENKINS_HOME"]
+        return value && value != ''
+      end
+
+      # Returns true if running in Travis CI
+      #
+      # Checks the value of TRAVIS
+      def self.travis?
+        value = ENV["TRAVIS"]
+        return value && value != ''
+      end
+
+      # Returns true if running in Circle CI
+      #
+      # Checks the value of CIRCLECI
+      def self.circle_ci?
+        value = ENV["CIRCLECI"]
+        return value && value != ''
+      end
+
+      # Returns true if running in Teamcity
+      #
+      # Checks the value of TEAMCITY_PROJECT_NAME
+      def self.teamcity?
+        value = ENV["TEAMCITY_PROJECT_NAME"]
+        return value && value != ''
+      end
+
+      # Returns true if running in a CI environment
+      def self.ci?
+        [
+          self.ci_var_defined?,
+          self.travis?,
+          self.jenkins?,
+          self.circle_ci?,
+          self.teamcity?
+        ].any?
+      end
+
+      # !@visibility private
+      def self.with_debugging(debug, &block)
+        if debug
+          original_value = ENV['DEBUG']
+
+          begin
+            ENV['DEBUG'] = '1'
+            block.call
+          ensure
+            ENV['DEBUG'] = original_value
+          end
+
+        else
+          block.call
+        end
+      end
+
+      private
+
+      # !@visibility private
+      def self.ci_var_defined?
+        value = ENV["CI"]
+        return value && value != ''
+      end
+    end
+  end
+end
+

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -30,7 +30,7 @@ module Calabash
       # Checks the value of JENKINS_HOME
       def self.jenkins?
         value = ENV["JENKINS_HOME"]
-        return value && value != ''
+        !!value && value != ''
       end
 
       # Returns true if running in Travis CI
@@ -38,7 +38,7 @@ module Calabash
       # Checks the value of TRAVIS
       def self.travis?
         value = ENV["TRAVIS"]
-        return value && value != ''
+        !!value && value != ''
       end
 
       # Returns true if running in Circle CI
@@ -46,7 +46,7 @@ module Calabash
       # Checks the value of CIRCLECI
       def self.circle_ci?
         value = ENV["CIRCLECI"]
-        return value && value != ''
+        !!value && value != ''
       end
 
       # Returns true if running in Teamcity
@@ -54,7 +54,7 @@ module Calabash
       # Checks the value of TEAMCITY_PROJECT_NAME
       def self.teamcity?
         value = ENV["TEAMCITY_PROJECT_NAME"]
-        return value && value != ''
+        !!value && value != ''
       end
 
       # Returns true if running in a CI environment
@@ -90,7 +90,7 @@ module Calabash
       # !@visibility private
       def self.ci_var_defined?
         value = ENV["CI"]
-        return value && value != ''
+        !!value && value != ''
       end
     end
   end

--- a/ruby-gem/lib/calabash-android/environment.rb
+++ b/ruby-gem/lib/calabash-android/environment.rb
@@ -1,12 +1,16 @@
 module Calabash
   module Android
+
+    # @!visibility private
     class Environment
 
+    # @!visibility private
       # Returns true if running on Windows
       def self.windows?
         RbConfig::CONFIG['host_os'][/mswin|mingw|cygwin/, 0] != nil
       end
 
+    # @!visibility private
       # Returns the user home directory
       def self.user_home_directory
         if self.xtc?
@@ -31,16 +35,19 @@ module Calabash
         end
       end
 
+      # @!visibility private
       # Returns true if debugging is enabled.
       def self.debug?
         ENV['DEBUG'] == '1'
       end
 
+      # @!visibility private
       # Returns true if we are running on the XTC
       def self.xtc?
         ENV['XAMARIN_TEST_CLOUD'] == '1'
       end
 
+      # @!visibility private
       # Returns true if running in Jenkins CI
       #
       # Checks the value of JENKINS_HOME
@@ -49,6 +56,7 @@ module Calabash
         !!value && value != ''
       end
 
+      # @!visibility private
       # Returns true if running in Travis CI
       #
       # Checks the value of TRAVIS
@@ -57,6 +65,7 @@ module Calabash
         !!value && value != ''
       end
 
+      # @!visibility private
       # Returns true if running in Circle CI
       #
       # Checks the value of CIRCLECI
@@ -65,6 +74,7 @@ module Calabash
         !!value && value != ''
       end
 
+      # @!visibility private
       # Returns true if running in Teamcity
       #
       # Checks the value of TEAMCITY_PROJECT_NAME
@@ -73,6 +83,7 @@ module Calabash
         !!value && value != ''
       end
 
+      # @!visibility private
       # Returns true if running in Teamcity
       #
       # Checks the value of GITLAB_CI
@@ -81,6 +92,7 @@ module Calabash
         !!value && value != ''
       end
 
+      # @!visibility private
       # Returns true if running in a CI environment
       def self.ci?
         [

--- a/ruby-gem/spec/lib/environment_spec.rb
+++ b/ruby-gem/spec/lib/environment_spec.rb
@@ -126,6 +126,28 @@ describe Calabash::Android::Environment do
     end
   end
 
+  describe ".gitlab?" do
+    it "returns true if GITLAB_CI is defined" do
+      stub_env({"GITLAB_CI" => true})
+
+      expect(Calabash::Android::Environment.gitlab?).to be == true
+    end
+
+    describe "returns false if GITLAB_CI undefined or empty" do
+      it "is nil" do
+        stub_env({"GITLAB_CI" => nil})
+
+        expect(Calabash::Android::Environment.gitlab?).to be == false
+      end
+
+      it "is empty string" do
+        stub_env({"GITLAB_CI" => ""})
+
+        expect(Calabash::Android::Environment.gitlab?).to be == false
+      end
+    end
+  end
+
   describe ".ci?" do
     describe "truthy" do
       it "CI" do
@@ -133,6 +155,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:travis?).and_return false
         expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return true
 
         expect(Calabash::Android::Environment.ci?).to be == true
@@ -143,6 +166,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:travis?).and_return false
         expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
         expect(Calabash::Android::Environment.ci?).to be == true
@@ -153,6 +177,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:travis?).and_return true
         expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
         expect(Calabash::Android::Environment.ci?).to be == true
@@ -163,6 +188,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:travis?).and_return false
         expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return true
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
         expect(Calabash::Android::Environment.ci?).to be == true
@@ -173,6 +199,18 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:travis?).and_return false
         expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return true
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(Calabash::Android::Environment.ci?).to be == true
+      end
+
+      it "GitLab" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:gitlab?).and_return true
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
         expect(Calabash::Android::Environment.ci?).to be == true
@@ -184,6 +222,7 @@ describe Calabash::Android::Environment do
       expect(Calabash::Android::Environment).to receive(:travis?).and_return false
       expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
       expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+      expect(Calabash::Android::Environment).to receive(:gitlab?).and_return false
       expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
       expect(Calabash::Android::Environment.ci?).to be == false

--- a/ruby-gem/spec/lib/environment_spec.rb
+++ b/ruby-gem/spec/lib/environment_spec.rb
@@ -42,20 +42,20 @@ describe Calabash::Android::Environment do
     it "returns true if JENKINS_HOME defined" do
       stub_env({"JENKINS_HOME" => "/Users/Shared/Jenkins"})
 
-      expect(Calabash::Android::Environment.jenkins?).to be_truthy
+      expect(Calabash::Android::Environment.jenkins?).to be == true
     end
 
     describe "returns false if JENKINS_HOME" do
       it "is nil" do
         stub_env({"JENKINS_HOME" => nil})
 
-        expect(Calabash::Android::Environment.jenkins?).to be_falsey
+        expect(Calabash::Android::Environment.jenkins?).to be == false
       end
 
       it "is empty string" do
         stub_env({"JENKINS_HOME" => ""})
 
-        expect(Calabash::Android::Environment.jenkins?).to be_falsey
+        expect(Calabash::Android::Environment.jenkins?).to be == false
       end
     end
   end
@@ -64,20 +64,20 @@ describe Calabash::Android::Environment do
     it "returns true if TRAVIS defined" do
       stub_env({"TRAVIS" => "some truthy value"})
 
-      expect(Calabash::Android::Environment.travis?).to be_truthy
+      expect(Calabash::Android::Environment.travis?).to be == true
     end
 
     describe "returns false if TRAVIS" do
       it "is nil" do
         stub_env({"TRAVIS" => nil})
 
-        expect(Calabash::Android::Environment.travis?).to be_falsey
+        expect(Calabash::Android::Environment.travis?).to be == false
       end
 
       it "is empty string" do
         stub_env({"TRAVIS" => ""})
 
-        expect(Calabash::Android::Environment.travis?).to be_falsey
+        expect(Calabash::Android::Environment.travis?).to be == false
       end
     end
   end
@@ -86,20 +86,20 @@ describe Calabash::Android::Environment do
     it "returns true if CIRCLECI defined" do
       stub_env({"CIRCLECI" => true})
 
-      expect(Calabash::Android::Environment.circle_ci?).to be_truthy
+      expect(Calabash::Android::Environment.circle_ci?).to be == true
     end
 
     describe "returns false if CIRCLECI" do
       it "is nil" do
         stub_env({"CIRCLECI" => nil})
 
-        expect(Calabash::Android::Environment.circle_ci?).to be_falsey
+        expect(Calabash::Android::Environment.circle_ci?).to be == false
       end
 
       it "is empty string" do
         stub_env({"CIRCLECI" => ""})
 
-        expect(Calabash::Android::Environment.circle_ci?).to be_falsey
+        expect(Calabash::Android::Environment.circle_ci?).to be == false
       end
     end
   end
@@ -108,20 +108,20 @@ describe Calabash::Android::Environment do
     it "returns true if TEAMCITY_PROJECT_NAME defined" do
       stub_env({"TEAMCITY_PROJECT_NAME" => "project name"})
 
-      expect(Calabash::Android::Environment.teamcity?).to be_truthy
+      expect(Calabash::Android::Environment.teamcity?).to be == true
     end
 
     describe "returns false if TEAMCITY_PROJECT_NAME" do
       it "is nil" do
         stub_env({"TEAMCITY_PROJECT_NAME" => nil})
 
-        expect(Calabash::Android::Environment.teamcity?).to be_falsey
+        expect(Calabash::Android::Environment.teamcity?).to be == false
       end
 
       it "is empty string" do
         stub_env({"TEAMCITY_PROJECT_NAME" => ""})
 
-        expect(Calabash::Android::Environment.teamcity?).to be_falsey
+        expect(Calabash::Android::Environment.teamcity?).to be == false
       end
     end
   end
@@ -135,7 +135,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return true
 
-        expect(Calabash::Android::Environment.ci?).to be_truthy
+        expect(Calabash::Android::Environment.ci?).to be == true
       end
 
       it "Jenkins" do
@@ -145,7 +145,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
-        expect(Calabash::Android::Environment.ci?).to be_truthy
+        expect(Calabash::Android::Environment.ci?).to be == true
       end
 
       it "Travis" do
@@ -155,7 +155,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
-        expect(Calabash::Android::Environment.ci?).to be_truthy
+        expect(Calabash::Android::Environment.ci?).to be == true
       end
 
       it "Circle CI" do
@@ -165,7 +165,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
-        expect(Calabash::Android::Environment.ci?).to be_truthy
+        expect(Calabash::Android::Environment.ci?).to be == true
       end
 
       it "TeamCity" do
@@ -175,7 +175,7 @@ describe Calabash::Android::Environment do
         expect(Calabash::Android::Environment).to receive(:teamcity?).and_return true
         expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
-        expect(Calabash::Android::Environment.ci?).to be_truthy
+        expect(Calabash::Android::Environment.ci?).to be == true
       end
     end
 
@@ -186,7 +186,7 @@ describe Calabash::Android::Environment do
       expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
       expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
 
-      expect(Calabash::Android::Environment.ci?).to be_falsey
+      expect(Calabash::Android::Environment.ci?).to be == false
     end
   end
 
@@ -196,20 +196,20 @@ describe Calabash::Android::Environment do
     it "returns true if CI defined" do
       stub_env({"CI" => true})
 
-      expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_truthy
+      expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be == true
     end
 
     describe "returns false if CI" do
       it "is nil" do
         stub_env({"CI" => nil})
 
-        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_falsey
+        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be == false
       end
 
       it "is empty string" do
         stub_env({"CI" => ""})
 
-        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_falsey
+        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be == false
       end
     end
   end

--- a/ruby-gem/spec/lib/environment_spec.rb
+++ b/ruby-gem/spec/lib/environment_spec.rb
@@ -1,0 +1,217 @@
+describe Calabash::Android::Environment do
+
+  describe ".user_home_directory" do
+    it "always returns a directory that exists" do
+      expect(File.exist?(Calabash::Android::Environment.user_home_directory)).to be_truthy
+    end
+
+    it "returns local ./tmp/home on the XTC" do
+      expect(Calabash::Android::Environment).to receive(:xtc?).and_return true
+
+      expected = File.join("./", "tmp", "home")
+      expect(Calabash::Android::Environment.user_home_directory).to be == expected
+      expect(File.exist?(expected)).to be_truthy
+    end
+  end
+
+  describe '.debug?' do
+    it "returns true when DEBUG == '1'" do
+      stub_env('DEBUG', '1')
+      expect(Calabash::Android::Environment.debug?).to be == true
+    end
+
+    it "returns false when DEBUG != '1'" do
+      stub_env('DEBUG', 1)
+      expect(Calabash::Android::Environment.debug?).to be == false
+    end
+  end
+
+  describe '.xtc?' do
+    it "returns true when XAMARIN_TEST_CLOUD == '1'" do
+      stub_env('XAMARIN_TEST_CLOUD', '1')
+      expect(Calabash::Android::Environment.xtc?).to be == true
+    end
+
+    it "returns false when XAMARIN_TEST_CLOUD != '1'" do
+      stub_env('XAMARIN_TEST_CLOUD', 1)
+      expect(Calabash::Android::Environment.xtc?).to be == false
+    end
+  end
+
+  describe ".jenkins?" do
+    it "returns true if JENKINS_HOME defined" do
+      stub_env({"JENKINS_HOME" => "/Users/Shared/Jenkins"})
+
+      expect(Calabash::Android::Environment.jenkins?).to be_truthy
+    end
+
+    describe "returns false if JENKINS_HOME" do
+      it "is nil" do
+        stub_env({"JENKINS_HOME" => nil})
+
+        expect(Calabash::Android::Environment.jenkins?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"JENKINS_HOME" => ""})
+
+        expect(Calabash::Android::Environment.jenkins?).to be_falsey
+      end
+    end
+  end
+
+  describe ".travis?" do
+    it "returns true if TRAVIS defined" do
+      stub_env({"TRAVIS" => "some truthy value"})
+
+      expect(Calabash::Android::Environment.travis?).to be_truthy
+    end
+
+    describe "returns false if TRAVIS" do
+      it "is nil" do
+        stub_env({"TRAVIS" => nil})
+
+        expect(Calabash::Android::Environment.travis?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"TRAVIS" => ""})
+
+        expect(Calabash::Android::Environment.travis?).to be_falsey
+      end
+    end
+  end
+
+  describe ".circle_ci?" do
+    it "returns true if CIRCLECI defined" do
+      stub_env({"CIRCLECI" => true})
+
+      expect(Calabash::Android::Environment.circle_ci?).to be_truthy
+    end
+
+    describe "returns false if CIRCLECI" do
+      it "is nil" do
+        stub_env({"CIRCLECI" => nil})
+
+        expect(Calabash::Android::Environment.circle_ci?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"CIRCLECI" => ""})
+
+        expect(Calabash::Android::Environment.circle_ci?).to be_falsey
+      end
+    end
+  end
+
+  describe ".teamcity?" do
+    it "returns true if TEAMCITY_PROJECT_NAME defined" do
+      stub_env({"TEAMCITY_PROJECT_NAME" => "project name"})
+
+      expect(Calabash::Android::Environment.teamcity?).to be_truthy
+    end
+
+    describe "returns false if TEAMCITY_PROJECT_NAME" do
+      it "is nil" do
+        stub_env({"TEAMCITY_PROJECT_NAME" => nil})
+
+        expect(Calabash::Android::Environment.teamcity?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"TEAMCITY_PROJECT_NAME" => ""})
+
+        expect(Calabash::Android::Environment.teamcity?).to be_falsey
+      end
+    end
+  end
+
+  describe ".ci?" do
+    describe "truthy" do
+      it "CI" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return true
+
+        expect(Calabash::Android::Environment.ci?).to be_truthy
+      end
+
+      it "Jenkins" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return true
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(Calabash::Android::Environment.ci?).to be_truthy
+      end
+
+      it "Travis" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return true
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(Calabash::Android::Environment.ci?).to be_truthy
+      end
+
+      it "Circle CI" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return true
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(Calabash::Android::Environment.ci?).to be_truthy
+      end
+
+      it "TeamCity" do
+        expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+        expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+        expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+        expect(Calabash::Android::Environment).to receive(:teamcity?).and_return true
+        expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(Calabash::Android::Environment.ci?).to be_truthy
+      end
+    end
+
+    it "falsey" do
+      expect(Calabash::Android::Environment).to receive(:jenkins?).and_return false
+      expect(Calabash::Android::Environment).to receive(:travis?).and_return false
+      expect(Calabash::Android::Environment).to receive(:circle_ci?).and_return false
+      expect(Calabash::Android::Environment).to receive(:teamcity?).and_return false
+      expect(Calabash::Android::Environment).to receive(:ci_var_defined?).and_return false
+
+      expect(Calabash::Android::Environment.ci?).to be_falsey
+    end
+  end
+
+  # private
+
+  describe ".ci_var_defined?" do
+    it "returns true if CI defined" do
+      stub_env({"CI" => true})
+
+      expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_truthy
+    end
+
+    describe "returns false if CI" do
+      it "is nil" do
+        stub_env({"CI" => nil})
+
+        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"CI" => ""})
+
+        expect(Calabash::Android::Environment.send(:ci_var_defined?)).to be_falsey
+      end
+    end
+  end
+end
+

--- a/ruby-gem/spec/lib/environment_spec.rb
+++ b/ruby-gem/spec/lib/environment_spec.rb
@@ -12,6 +12,27 @@ describe Calabash::Android::Environment do
       expect(Calabash::Android::Environment.user_home_directory).to be == expected
       expect(File.exist?(expected)).to be_truthy
     end
+
+    describe "Windows" do
+
+      before do
+        expect(Calabash::Android::Environment).to receive(:windows?).and_return true
+      end
+
+      it "returns HOME if it is defined" do
+        stub_env({"HOME" => "C:\\my\\home\\dir"})
+        expect(File).to receive(:exist?).with("C:\\my\\home\\dir").and_return true
+
+        expect(Calabash::Android::Environment.user_home_directory).to be == "C:\\my\\home\\dir"
+      end
+
+      it "returns USERPROFILE if HOME is not defined" do
+        stub_env({"USERPROFILE" => "C:\\my\\home\\dir", "HOME" => nil})
+        expect(File).to receive(:exist?).with("C:\\my\\home\\dir").and_return true
+
+        expect(Calabash::Android::Environment.user_home_directory).to be == "C:\\my\\home\\dir"
+      end
+    end
   end
 
   describe '.debug?' do


### PR DESCRIPTION
### Motivation

Progress on **Add usage tracking** #655

* Need user's home directory to manage ~/.calabash
* Need CI methods for statistics

I choose to make a new file rather than add the methods to `environment_helpers.rb` or to `env.rb`

* It was easier to port to `Calabash::Android::Environment` in `environment.rb`.
* The `Env` module is defined in the _top level_ namespace and I believe it is used mostly for the build script? I think it is better to have these methods defined in the `Calabash::Android` namespace/module.
* Putting the methods in `EnvironmentHelpers` was tempting, but I opted not to put them there because we may or may not want these methods available as part of the public API.  If they were in `EnvironmentHelpers` they would be available to cucumber.