### PR TITLE
Travis: add #calabash-ci slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ notifications:
       - tobias.roikjer@xamarin.com
     on_success: change
     on_failure: always
-
+  slack:
+    rooms:
+      secure: fZynvMX0+leWS5FRv8aDaMGhV5dbxGhs3ed6slhLfB6oEUlS9u+VGT1jZuKCSODW4E4Ao2xUziVdRwe/cCIYkgbuIlhJtb/gUI0lIlx7bBC17/8uydFcthukA/KYw8kyArWZkEyC+eixQhixju3BUYAylbepgRtA62DUnbxyh5Q=


### PR DESCRIPTION
### Motivation

I want to try Slack notifications again for Travis CI.

Iterating with Travis support re: encrypting the token.