### PR TITLE
Rspec: stablize logging spec on Windows

### DIFF
--- a/ruby-gem/spec/lib/logging_spec.rb
+++ b/ruby-gem/spec/lib/logging_spec.rb
@@ -139,6 +139,10 @@ describe Calabash::Android::Logging do
            end.string.gsub(/\e\[(\d+)m/, "")
 
            expected = "DEBUG: Could not write:\n\nmessage\n\nto calabash.log because:\n\nDid not get the last hit\n\n"
+
+           actual.gsub!($-0, "")
+           expected.gsub!($-0, "")
+
            expect(actual).to be == expected
         end
 


### PR DESCRIPTION
### Motivation

In Windows CI:

```
08:40:40   1) Calabash::Android::Logging file logging logs directory and calabash.log .log_to_file handles errors by logging when debugging
08:40:40      Failure/Error: expect(actual).to be == expected
08:40:40 
08:40:40        expected: == "DEBUG: Could not write:\n\nmessage\n\nto calabash.log because:\n\nDid not get the last hit\n\n"
08:40:40             got:    "DEBUG: Could not write:\n\nmessage\n\nto calabash.log because:\n\nDid not get the last hit\n"
08:40:40      # C:/Program Files (x86)/Jenkins/jobs/Calabash Android/workspace/ruby-gem/spec/lib/logging_spec.rb:142:in `block (5 levels) in <top (required)>'
```

Also testing Windows Jenkins CI: GHPRB