### PR TITLE
Increase the poll-rate for the server to be ready.

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -656,12 +656,12 @@ module Calabash module Android
         log cmd
         raise "Could not execute command to start test server" unless system("#{cmd} 2>&1")
 
-        Retriable.retriable :tries => 10, :interval => 1 do
+        Retriable.retriable :tries => 100, :interval => 0.1 do
           raise "App did not start" unless app_running?
         end
 
         begin
-          Retriable.retriable :tries => 10, :interval => 3 do
+          Retriable.retriable :tries => 300, :interval => 0.1 do
             log "Checking if instrumentation backend is ready"
 
             log "Is app running? #{app_running?}"


### PR DESCRIPTION
## Problem
Calabash-Android takes a long time to start the app

## Solution
Increase the poll-rate for the server to be ready.

## Issue
https://github.com/calabash/calabash-android/issues/670