### PR TITLE
quit/kill monkey server after gestures

### DIFF
--- a/ruby-gem/lib/calabash-android/monkey_helpers.rb
+++ b/ruby-gem/lib/calabash-android/monkey_helpers.rb
@@ -26,6 +26,8 @@ module Calabash
 
         sleep(args.fetch(:hang_time))
         monkey_touch(:up, to_x, to_y)
+
+        kill_existing_monkey_processes
       end
 
       def get_monkey_port
@@ -65,6 +67,7 @@ module Calabash
       end
 
       def kill_monkey_processes_on_device
+        perform_action('send_tcp', @@monkey_port, "quit", true) unless @@monkey_port.nil?
         existing_monkey_pids.each do |pid|
           `#{adb_command} shell kill -9 #{pid}`
         end
@@ -102,6 +105,7 @@ module Calabash
         start_monkey if should_start_monkey
         monkey_touch(:down, x, y)
         monkey_touch(:up, x, y)
+        kill_existing_monkey_processes
       end
 
       def monkey_touch(touch_type, x, y)


### PR DESCRIPTION
In certain scenarios, future gestures can fail if a monkey server used to perform a drag gesture (and possibly other gestures) is still running.

@TobiasRoikjer Could you review please?