### PR TITLE
Handle spaces within the path to ruby/calabash-android

### DIFF
--- a/ruby-gem/bin/calabash-android-run.rb
+++ b/ruby-gem/bin/calabash-android-run.rb
@@ -28,7 +28,7 @@ def calabash_run(app_path = nil)
 
   STDOUT.sync = true
   arguments = ARGV - ["--no-build"]
-  cmd = "#{RbConfig.ruby} -S cucumber #{arguments.join(" ")} #{env}"
+  cmd = "\"#{RbConfig.ruby}\" -S cucumber #{arguments.join(" ")} #{env}"
   log cmd
   exit_code = system(cmd)
 

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -542,7 +542,7 @@ module Calabash module Android
             f.write res
           end
         else
-          screenshot_cmd = "java -jar #{File.join(File.dirname(__FILE__), 'lib', 'screenshotTaker.jar')} #{serial} \"#{path}\""
+          screenshot_cmd = "java -jar \"#{File.join(File.dirname(__FILE__), 'lib', 'screenshotTaker.jar')}\" #{serial} \"#{path}\""
           log screenshot_cmd
           raise "Could not take screenshot" unless system(screenshot_cmd)
         end


### PR DESCRIPTION
Addresses `calabash-android run` failures when using the Calabash sandbox on Windows as a user with a space in the username.  Will also support any other scenario where the path to ruby or the calabash-android gem contains a space.

@TobiasRoikjer:  Could you review and test this on OS-X please?