### PR TITLE
Fix for the issue #716

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -607,8 +607,8 @@ module Calabash module Android
 
       def connected_devices
         lines = `"#{Calabash::Android::Dependencies.adb_path}" devices`.split("\n")
-        start_index = lines.index{ |x| x =~ /List of devices attached/ } + 1
-        lines[start_index..-1].collect { |l| l.split("\t").first }
+        raw_devices = lines.select { |line| line !~ /List of devices attached|\*.+\*/ }
+        raw_devices.collect { |l| l.split("\t").first }
       end
 
       def wake_up


### PR DESCRIPTION
That issue happens when adb server is stopped, and after invoking `adb devices` system first starts the server and then gets attached devices. Log example:
```
$ adb devices
List of devices attached
* daemon not running. starting it now on port 5037 *
* daemon started successfully *
043a3949252487ca	device
```

You can reproduce this issue if you type `adb kill-server` before running tests.

