### PR TITLE
Jenkins: add a batch file for running on Windows

### DIFF
--- a/bin/ci/windows.bat
+++ b/bin/ci/windows.bat
@@ -1,0 +1,4 @@
+call cd ruby-gem
+call gem update --system
+call bundle update
+call bundle exec rake test

--- a/bin/ci/windows.bat
+++ b/bin/ci/windows.bat
@@ -1,4 +1,4 @@
 call cd ruby-gem
 call gem update --system
 call bundle update
-call bundle exec rake test
+call bundle exec rspec spec

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -41,7 +41,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency( 'rake', '~> 10.3' )
   s.add_development_dependency( 'yard', '~> 0.8' )
-  s.add_development_dependency( 'redcarpet', '~> 3.1' )
+  puts RUBY_PLATFORM
+  if RUBY_PLATFORM[/darwin/] || RUBY_PLATFORM["linux"]
+    s.add_development_dependency( 'redcarpet', '~> 3.1' )
+  end
   s.add_development_dependency( "rspec_junit_formatter" )
   s.add_development_dependency( "rspec", "~> 3.0" )
   s.add_development_dependency( "pry" )


### PR DESCRIPTION
### Motivation

1. Jenkins is inserting unix newlines into scripts edited from Jenkins web UI.
2. redcarpet does not install on Windows and is not required there (development dependency).

