### PR TITLE
CI: update Travis configuration and fix Windows Jenkins test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ os:
   - linux
   - osx
 
+# rvm ships with a version of gem and bundler that is too old.
+before_install:
+  - gem update --system
+  - gem --version
+  - gem uninstall -Vax --force --no-abort-on-dependent bundler
+  - gem install bundler --version 1.12.5
+  - bundler --version
+
 rvm:
   - 2.0.0
   - 2.1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
   - gem install bundler --version 1.12.5
   - bundler --version
 
+# rvm does not support any ruby 2.3 as of Jun 11 2016
 rvm:
-  - 2.0.0
-  - 2.1.2
+  - 2.1.5
   - 2.2.3
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-# Run on linux
 language: ruby
 
 # Container based: faster
 sudo: false
+
+os:
+  - linux
+  - osx
 
 rvm:
   - 2.0.0

--- a/bin/ci/travis/run.sh
+++ b/bin/ci/travis/run.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
 cd ruby-gem
-bundle update
 
 touch lib/calabash-android/lib/TestServer.apk
+touch lib/calabash-android/lib/AndroidManifest.xml
+
+bundle update
+
 gem build calabash-android.gemspec
 
 bundle exec rake unit

--- a/bin/ci/windows.bat
+++ b/bin/ci/windows.bat
@@ -1,0 +1,4 @@
+call cd ruby-gem
+call gem update --system
+call bundle update
+call bundle exec rake test

--- a/bin/ci/windows.bat
+++ b/bin/ci/windows.bat
@@ -1,4 +1,4 @@
 call cd ruby-gem
 call gem update --system
 call bundle update
-call bundle exec rake test
+call bundle exec rspec spec

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -41,7 +41,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency( 'rake', '~> 10.3' )
   s.add_development_dependency( 'yard', '~> 0.8' )
-  s.add_development_dependency( 'redcarpet', '~> 3.1' )
+  puts RUBY_PLATFORM
+  if RUBY_PLATFORM[/darwin/] || RUBY_PLATFORM["linux"]
+    s.add_development_dependency( 'redcarpet', '~> 3.1' )
+  end
   s.add_development_dependency( "rspec_junit_formatter" )
   s.add_development_dependency( "rspec", "~> 3.0" )
   s.add_development_dependency( "pry" )


### PR DESCRIPTION
### Motivation

Replaces: Jenkins: add a batch file for running on Windows #737

1. Jenkins is inserting unix newlines into scripts edited from Jenkins web UI - use `bin/ci/windows.bat` on Jenkins
2. redcarpet does not install on Windows and is not required there (development dependency) - don't install on Windows
3. There is no CI job on macOS - update `.travis.yml` to run on macOS and Linux
4. Limit the number of ruby versions tested on Travis.
5. Add `before_install` section to get a good version of rubygems and bundler installed