### PR TITLE
Fix deprecated method in "I press the enter button"

### DIFF
--- a/ruby-gem/lib/calabash-android/steps/navigation_steps.rb
+++ b/ruby-gem/lib/calabash-android/steps/navigation_steps.rb
@@ -7,7 +7,8 @@ Then /^I press the menu key$/ do
 end
 
 Then /^I press the enter button$/ do
-  perform_action('send_key_enter')
+  press_user_action_button
+  # Or, possibly, press_enter_button
 end
 
 


### PR DESCRIPTION
perform_action('send_key_enter') has a deprecated warning  but is used in the "^I press the enter button" step defined in steps/navigation_steps.rb

press_enter_button is its direct replacement, but maybe press_user_action_button is more appropriate for a general step like this.