### PR TITLE
Update rubyzip dependency

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( 'retriable', '>= 1.3.3.1', '< 1.5')
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", "~> 1.1" )
+  s.add_dependency( "rubyzip", "~> 1.2" )
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.3.2', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')


### PR DESCRIPTION
when used in conjunction with calabash-cucumber / fastlane gem the outdated
rubyzip dependency stops you from using calabash-android.

Since rubyzip 1.1 -> 1.2 did not introduce breaking changes for our use case, we
can upgrade it safely