### PR TITLE
Update retrieable to 2.x

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency( "cucumber" )
   s.add_dependency( "json", '~> 1.8' )
-  s.add_dependency( 'retriable', '>= 1.3.3.1', '< 1.5')
+  s.add_dependency( 'retriable', '~> 2.0')
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print", '~> 1.2')

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -618,7 +618,7 @@ module Calabash module Android
         log wake_up_cmd
         raise "Could not wake up the device" unless system(wake_up_cmd)
 
-        Retriable.retriable :tries => 10, :interval => 1 do
+        Retriable.retriable :tries => 10, :base_interval => 1 do
           raise "Could not remove the keyguard" if keyguard_enabled?
         end
       end
@@ -668,12 +668,12 @@ module Calabash module Android
         log cmd
         raise "Could not execute command to start test server" unless system("#{cmd} 2>&1")
 
-        Retriable.retriable :tries => 100, :interval => 0.1 do
+        Retriable.retriable :tries => 100, :base_interval => 0.1 do
           raise "App did not start" unless app_running?
         end
 
         begin
-          Retriable.retriable :tries => 300, :interval => 0.1 do
+          Retriable.retriable :tries => 300, :base_interval => 0.1 do
             log "Checking if instrumentation backend is ready"
 
             log "Is app running? #{app_running?}"


### PR DESCRIPTION
when used in conjunction with calabash-cucumber / fastlane gem the outdated
retrieable dependency stops you from using calabash-android.