### PR TITLE
Remove retriable dependency

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency( "cucumber" )
   s.add_dependency( "json", '~> 1.8' )
-  s.add_dependency( 'retriable', '>= 1.3.3.1', '< 1.5')
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )
   s.add_dependency( "awesome_print", '~> 1.2')

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -18,10 +18,10 @@ require 'calabash-android/env'
 require 'calabash-android/environment'
 require 'calabash-android/dot_dir'
 require 'calabash-android/logging'
+require 'calabash-android/retryable'
 require 'calabash-android/store/preferences'
 require 'calabash-android/usage_tracker'
 require 'calabash-android/dependencies'
-require 'retriable'
 require 'cucumber'
 require 'date'
 require 'time'
@@ -284,6 +284,8 @@ module Calabash module Android
 
     class Device
       attr_reader :app_path, :test_server_path, :serial, :server_port, :test_server_port
+
+      include Calabash::Android::Retryable
 
       def initialize(cucumber_world, serial, server_port, app_path, test_server_path, test_server_port = 7102)
 
@@ -618,7 +620,7 @@ module Calabash module Android
         log wake_up_cmd
         raise "Could not wake up the device" unless system(wake_up_cmd)
 
-        Retriable.retriable :tries => 10, :interval => 1 do
+        retriable :tries => 10, :interval => 1 do
           raise "Could not remove the keyguard" if keyguard_enabled?
         end
       end
@@ -668,12 +670,12 @@ module Calabash module Android
         log cmd
         raise "Could not execute command to start test server" unless system("#{cmd} 2>&1")
 
-        Retriable.retriable :tries => 100, :interval => 0.1 do
+        retriable :tries => 100, :interval => 0.1 do
           raise "App did not start" unless app_running?
         end
 
         begin
-          Retriable.retriable :tries => 300, :interval => 0.1 do
+          retriable :tries => 300, :interval => 0.1 do
             log "Checking if instrumentation backend is ready"
 
             log "Is app running? #{app_running?}"

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -18,7 +18,7 @@ require 'calabash-android/env'
 require 'calabash-android/environment'
 require 'calabash-android/dot_dir'
 require 'calabash-android/logging'
-require 'calabash-android/retryable'
+require 'calabash-android/retry'
 require 'calabash-android/store/preferences'
 require 'calabash-android/usage_tracker'
 require 'calabash-android/dependencies'
@@ -284,8 +284,6 @@ module Calabash module Android
 
     class Device
       attr_reader :app_path, :test_server_path, :serial, :server_port, :test_server_port
-
-      include Calabash::Android::Retryable
 
       def initialize(cucumber_world, serial, server_port, app_path, test_server_path, test_server_port = 7102)
 
@@ -620,7 +618,7 @@ module Calabash module Android
         log wake_up_cmd
         raise "Could not wake up the device" unless system(wake_up_cmd)
 
-        retriable :tries => 10, :interval => 1 do
+        Calabash::Android::Retry.retry :tries => 10, :interval => 1 do
           raise "Could not remove the keyguard" if keyguard_enabled?
         end
       end
@@ -670,12 +668,12 @@ module Calabash module Android
         log cmd
         raise "Could not execute command to start test server" unless system("#{cmd} 2>&1")
 
-        retriable :tries => 100, :interval => 0.1 do
+        Calabash::Android::Retry.retry :tries => 100, :interval => 0.1 do
           raise "App did not start" unless app_running?
         end
 
         begin
-          retriable :tries => 300, :interval => 0.1 do
+          Calabash::Android::Retry.retry :tries => 300, :interval => 0.1 do
             log "Checking if instrumentation backend is ready"
 
             log "Is app running? #{app_running?}"

--- a/ruby-gem/lib/calabash-android/retry.rb
+++ b/ruby-gem/lib/calabash-android/retry.rb
@@ -1,9 +1,7 @@
 module Calabash
   module Android
-    module Retryable
-
-
-      def retriable(opts, &blk)
+    module Retry
+      def self.retry(opts, &blk)
         tries = opts[:tries]
         interval = opts[:interval]
 

--- a/ruby-gem/lib/calabash-android/retryable.rb
+++ b/ruby-gem/lib/calabash-android/retryable.rb
@@ -1,0 +1,26 @@
+module Calabash
+  module Android
+    module Retryable
+
+
+      def retriable(opts, &blk)
+        tries = opts[:tries]
+        interval = opts[:interval]
+
+        tries.times do |try|
+          begin
+            blk.call
+            return
+
+          rescue => e
+            if (try + 1) >= tries
+              raise
+            else
+              sleep interval
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/ruby-gem/spec/lib/retryable_spec.rb
+++ b/ruby-gem/spec/lib/retryable_spec.rb
@@ -1,16 +1,10 @@
 require 'stringio'
 
-describe Calabash::Android::Retryable do
-  class StubObject
-    include Calabash::Android::Retryable
-  end
-
-  describe ".retriable" do
-    subject { StubObject.new }
-
+describe Calabash::Android::Retry do
+  describe "#retry" do
     it 'retries' do
       expect {
-        subject.retriable({ tries: 2, interval: 0.01 }) do
+        Calabash::Android::Retry.retry({ tries: 2, interval: 0.01 }) do
           raise "foo"
         end
       }.to raise_error(RuntimeError)
@@ -19,7 +13,7 @@ describe Calabash::Android::Retryable do
     it 'succeeds' do
       expect {
         nr = 0
-        subject.retriable({ tries: 2, interval: 0.01 }) do
+        Calabash::Android::Retry.retry({ tries: 2, interval: 0.01 }) do
           nr = nr + 1
           if nr == 2
             :ok

--- a/ruby-gem/spec/lib/retryable_spec.rb
+++ b/ruby-gem/spec/lib/retryable_spec.rb
@@ -1,0 +1,33 @@
+require 'stringio'
+
+describe Calabash::Android::Retryable do
+  class StubObject
+    include Calabash::Android::Retryable
+  end
+
+  describe ".retriable" do
+    subject { StubObject.new }
+
+    it 'retries' do
+      expect {
+        subject.retriable({ tries: 2, interval: 0.01 }) do
+          raise "foo"
+        end
+      }.to raise_error(RuntimeError)
+    end
+
+    it 'succeeds' do
+      expect {
+        nr = 0
+        subject.retriable({ tries: 2, interval: 0.01 }) do
+          nr = nr + 1
+          if nr == 2
+            :ok
+          else
+            raise :fail
+          end
+        end
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Approach to remove the retrieable dependency.

Since our use case is quite simple, this simple approach ought to be enough.

See #743