### PR TITLE
touch(nil) throws INJECT_EVENTS permission

### DIFF
--- a/ruby-gem/lib/calabash-android/gestures.rb
+++ b/ruby-gem/lib/calabash-android/gestures.rb
@@ -143,6 +143,7 @@ module Calabash
         end
 
         def self.with_parameters(multi_touch_gesture, params={})
+          raise "Query string can not be nil" if params[:query_string].nil?
           multi_touch_gesture.query_string = params[:query_string] if params[:query_string]
           multi_touch_gesture.timeout = params[:timeout] if params[:timeout]
 

--- a/ruby-gem/lib/calabash-android/gestures.rb
+++ b/ruby-gem/lib/calabash-android/gestures.rb
@@ -143,7 +143,6 @@ module Calabash
         end
 
         def self.with_parameters(multi_touch_gesture, params={})
-          raise "Query string can not be nil" if params[:query_string].nil?
           multi_touch_gesture.query_string = params[:query_string] if params[:query_string]
           multi_touch_gesture.timeout = params[:timeout] if params[:timeout]
 

--- a/ruby-gem/lib/calabash-android/touch_helpers.rb
+++ b/ruby-gem/lib/calabash-android/touch_helpers.rb
@@ -29,6 +29,9 @@ module Calabash
 
           perform_action("touch_coordinate", center_x, center_y)
         else
+          if query_string.nil? && (options.nil? || options.empty?)
+            raise "Can't touch nil"
+          end
           execute_gesture(Gesture.with_parameters(Gesture.tap(options), {query_string: query_string}.merge(options)))
         end
       end


### PR DESCRIPTION
touch(some_operation_which_results_in_nil_instead_of_valid_query_result) throws RuntimeError  
eg. touch(nil)  
RuntimeError: Failed to perform gesture. java.lang.SecurityException: Injecting to another application requires INJECT_EVENTS permission  
Throwing more user-friendly exception in case query_string is nil.