### PR TITLE
Problem: Rubyzip warns of invalid date in gradle APKs

### DIFF
--- a/ruby-gem/bin/calabash-android
+++ b/ruby-gem/bin/calabash-android
@@ -53,6 +53,7 @@ else
             print_help
         when 'build'
             require 'calabash-android/helpers'
+            require 'calabash-android/utils'
             require 'calabash-android/java_keystore'
             require 'calabash-android/env'
             require File.join(File.dirname(__FILE__), "calabash-android-build")

--- a/ruby-gem/bin/calabash-android-build.rb
+++ b/ruby-gem/bin/calabash-android-build.rb
@@ -50,20 +50,22 @@ def calabash_build(app)
         raise "Could not create dummy.apk"
       end
 
-      Zip::File.new("dummy.apk").extract("AndroidManifest.xml","customAndroidManifest.xml")
-      Zip::File.open("TestServer.apk") do |zip_file|
-        begin
-          check_file("AndroidManifest.xml")
-          manifest_exists = true
-        rescue
-          manifest_exists = false
-        end
+      Calabash::Utils.with_silent_zip do
+        Zip::File.new("dummy.apk").extract("AndroidManifest.xml","customAndroidManifest.xml")
+        Zip::File.open("TestServer.apk") do |zip_file|
+          begin
+            check_file("AndroidManifest.xml")
+            manifest_exists = true
+          rescue
+            manifest_exists = false
+          end
 
-        if manifest_exists
-          zip_file.remove("AndroidManifest.xml")
-        end
+          if manifest_exists
+            zip_file.remove("AndroidManifest.xml")
+          end
 
-        zip_file.add("AndroidManifest.xml", "customAndroidManifest.xml")
+          zip_file.add("AndroidManifest.xml", "customAndroidManifest.xml")
+        end
       end
     end
     keystore.sign_apk("#{workspace_dir}/TestServer.apk", test_server_file_name)

--- a/ruby-gem/lib/calabash-android.rb
+++ b/ruby-gem/lib/calabash-android.rb
@@ -1,3 +1,4 @@
+require 'calabash-android/utils'
 require 'calabash-android/defaults'
 require 'calabash-android/environment'
 require 'calabash-android/dot_dir'

--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -169,9 +169,13 @@ def fingerprint_from_apk(app_path)
     Dir.chdir(tmp_dir) do
       FileUtils.cp(app_path, "app.apk")
       FileUtils.mkdir("META-INF")
-      Zip::File.foreach("app.apk") do |z|
-        z.extract if /^META-INF\/\w+.(rsa|dsa)/i =~ z.name
+
+      Calabash::Utils.with_silent_zip do
+        Zip::File.foreach("app.apk") do |z|
+          z.extract if /^META-INF\/\w+.(rsa|dsa)/i =~ z.name
+        end
       end
+
       signature_files = Dir["#{tmp_dir}/META-INF/*"]
 
       log 'Signature files:'

--- a/ruby-gem/lib/calabash-android/utils.rb
+++ b/ruby-gem/lib/calabash-android/utils.rb
@@ -1,0 +1,25 @@
+require 'zip'
+
+module Calabash
+  module Utils
+    def self.with_silent_zip(&block)
+      previous_value = false
+
+      if Zip.respond_to?(:warn_invalid_date)
+        previous_value = Zip.warn_invalid_date
+      end
+
+      if Zip.respond_to?(:warn_invalid_date=)
+        Zip.warn_invalid_date = false
+      end
+
+      r = block.call
+
+      if Zip.respond_to?(:warn_invalid_date=)
+        Zip.warn_invalid_date = previous_value
+      end
+
+      r
+    end
+  end
+end

--- a/ruby-gem/spec/lib/utils_spec.rb
+++ b/ruby-gem/spec/lib/utils_spec.rb
@@ -1,0 +1,56 @@
+describe Calabash::Utils do
+  describe 'with_silent_zip' do
+    it 'is a method that takes a block and evaluates it' do
+      expect(Calabash::Utils.with_silent_zip do
+        2+2
+      end).to eq(4)
+    end
+
+    it 'disables zip warnings about invalid date if zip responds to it' do
+      stub_const("Zip", Module.new do
+        @warn_invalid_date = true
+
+        def self.warn_invalid_date
+          @warn_invalid_date
+        end
+
+        def self.warn_invalid_date=(value)
+          @warn_invalid_date = value
+        end
+      end)
+
+      expect(Calabash::Utils.with_silent_zip do
+        Zip.warn_invalid_date
+      end).to eq(false)
+    end
+
+    it 'does not try to disable zip warnings about invalid date if zip does not respond to it' do
+      stub_const("Zip", Module.new do
+      end)
+
+      expect(Calabash::Utils.with_silent_zip do
+        2+2
+      end).to eq(4)
+    end
+
+    it 'resets zip warnings about invalid date if zip responds to it' do
+      stub_const("Zip", Module.new do
+        @warn_invalid_date = :default_value
+
+        def self.warn_invalid_date
+          @warn_invalid_date
+        end
+
+        def self.warn_invalid_date=(value)
+          @warn_invalid_date = value
+        end
+      end)
+
+      expect(Calabash::Utils.with_silent_zip do
+        Zip.warn_invalid_date
+      end).to eq(false)
+
+      expect(Zip.warn_invalid_date).to eq(:default_value)
+    end
+  end
+end


### PR DESCRIPTION
Solution: Silence Rubyzip date warnings if the version of Rubyzip the
user is using supports it.