### PR TITLE
Require Calabash::Utils in helpers.rb

### DIFF
--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -8,6 +8,7 @@ require 'calabash-android/environment'
 require 'calabash-android/logging'
 require 'calabash-android/dependencies'
 require 'calabash-android/version'
+require 'calabash-android/utils'
 
 def package_name(app)
   unless File.exist?(app)


### PR DESCRIPTION
`Calabash::Utils` was introduced in version 0.8.4. The helpers.rb uses methods from it but does not `require` it.