### PR TITLE
Expand paths when detecting Android SDK

### DIFF
--- a/ruby-gem/lib/calabash-android/dependencies.rb
+++ b/ruby-gem/lib/calabash-android/dependencies.rb
@@ -391,17 +391,17 @@ module Calabash
                     end
                 end
 
-                if File.exist?('~/Library/Developer/Xamarin/android-sdk-mac_x86/')
-                    return '~/Library/Developer/Xamarin/android-sdk-mac_x86/'
+                if File.exist?(File.expand_path('~/Library/Developer/Xamarin/android-sdk-mac_x86/'))
+                    return File.expand_path('~/Library/Developer/Xamarin/android-sdk-mac_x86/')
                 end
                 
-                if File.exist?('~/Library/Developer/Xamarin/android-sdk-macosx/')
-                    return '~/Library/Developer/Xamarin/android-sdk-macosx/'
+                if File.exist?(File.expand_path('~/Library/Developer/Xamarin/android-sdk-macosx/'))
+                    return File.expand_path('~/Library/Developer/Xamarin/android-sdk-macosx/')
                 end
                 
                 # Default location when installing with Android Studio
-                if File.exist?('~/Library/Android/sdk/')
-                    return '~/Library/Android/sdk/'
+                if File.exist?(File.expand_path('~/Library/Android/sdk/'))
+                    return File.expand_path('~/Library/Android/sdk/')
                 end
                 
                 if File.exist?('C:\\Android\\android-sdk')


### PR DESCRIPTION
I've experienced that the detection fails on our machines, but when the path is expanded the detection succeeds.