### PR TITLE
Fix: permissions not granted on app update

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -390,7 +390,7 @@ module Calabash module Android
 
       def update_app(app_path)
         if _sdk_version >= 23
-          cmd = "#{adb_command} install -rg \"#{app_path}\""
+          cmd = "#{adb_command} install -r -g \"#{app_path}\""
         else
           cmd = "#{adb_command} install -r \"#{app_path}\""
         end


### PR DESCRIPTION
When updating an app (using `Calabash::Android::Operations.update_app`) from a version A with sdk version < 23 to a version B with sdk version >= 23, the android permissions are not automatically granted.
This happens because adb flags must be sent separately. `adb install -rg` will only update app, `g` option is ignored.

With `adb install -r -g` it successfully updates the app AND grants permissions.

I tested it with calabash-android 0.9.0 and adb version 1.0.36