### PR TITLE
irbrc should capture all errors: otherwise, irb silently eats them.

### DIFF
--- a/ruby-gem/irbrc
+++ b/ruby-gem/irbrc
@@ -1,40 +1,45 @@
-require 'rubygems'
-require 'irb/completion'
-require 'irb/ext/save-history'
-
 begin
-  require 'awesome_print'
-rescue LoadError => e
-  msg = ["Caught a LoadError: could not load 'awesome_print'",
-         "#{e}",
-         '',
-         'Use bundler (recommended) or uninstall awesome_print.',
-         '',
-         '# Use bundler (recommended)',
-         '$ bundle update',
-         '$ bundle exec calabash-android console <path to apk>',
-         '',
-         '# Uninstall',
-         '$ gem update --system',
-         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
-  puts msg
+  require 'rubygems'
+  require 'irb/completion'
+  require 'irb/ext/save-history'
+
+  begin
+    require 'awesome_print'
+  rescue LoadError => e
+    msg = ["Caught a LoadError: could not load 'awesome_print'",
+          "#{e}",
+          '',
+          'Use bundler (recommended) or uninstall awesome_print.',
+          '',
+          '# Use bundler (recommended)',
+          '$ bundle update',
+          '$ bundle exec calabash-android console <path to apk>',
+          '',
+          '# Uninstall',
+          '$ gem update --system',
+          '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+    puts msg
+    exit(1)
+  end
+
+  AwesomePrint.irb!
+
+  ARGV.concat [ "--readline",
+                "--prompt-mode",
+                "simple" ]
+
+  # 50 entries in the list
+  IRB.conf[:SAVE_HISTORY] = 50
+
+  # Store results in home directory with specified file name
+  IRB.conf[:HISTORY_FILE] = ".irb-history"
+
+  require 'calabash-android/defaults'
+  require 'calabash-android/operations'
+rescue Exception => e
+  puts "Error loading Calabash irbrc: #{e}"
   exit(1)
 end
-
-AwesomePrint.irb!
-
-ARGV.concat [ "--readline",
-              "--prompt-mode",
-              "simple" ]
-
-# 50 entries in the list
-IRB.conf[:SAVE_HISTORY] = 50
-
-# Store results in home directory with specified file name
-IRB.conf[:HISTORY_FILE] = ".irb-history"
-
-require 'calabash-android/defaults'
-require 'calabash-android/operations'
 
 module Calabash
   module Android


### PR DESCRIPTION
All this does is wrap the logic executed by irbrc into a custom error handler that dumps the error to console.  Unfortunately, GitHub's differ is making it look like a bigger change than it is.

The old approach only rescued LoadErrors from awesomeprint, but other failures are possible outside of that.

I just ran into this as a user, on account of a brew upgrade on my laptop replacing a GNU Readline shared object that my copy of ruby built by ruby-build was depending on, causing Calabash's irbrc's `require 'irb/ext/save-history'` fail.  This patch makes such failures no longer silent.