### PR TITLE
Removing done from operations to fix #722

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -1122,10 +1122,6 @@ module Calabash module Android
       ni
     end
 
-    def done
-      ni
-    end
-
     def find_scrollable_view(options={})
       timeout = options[:timeout] || 30
 


### PR DESCRIPTION
`done` in `operations.rb` is no longer being used and can be safely removed.

For: https://github.com/calabash/calabash-android/issues/722