### PR TITLE
Fixed: error when repeated calling funciton send_tcp()

### DIFF
--- a/ruby-gem/lib/calabash-android/monkey_helpers.rb
+++ b/ruby-gem/lib/calabash-android/monkey_helpers.rb
@@ -99,6 +99,8 @@ module Calabash
       def kill_existing_monkey_processes
         kill_monkey_processes_on_host
         kill_monkey_processes_on_device
+        @@monkey_port = nil
+        @@monkey_pid = nil
       end
 
       def monkey_tap(x, y, should_start_monkey=true)


### PR DESCRIPTION
Solve error from https://github.com/calabash/calabash-android/issues/740
Simply reset two variables after killing process
```
      @@monkey_port = nil
      @@monkey_pid  = nil
```