### PR TITLE
Remove usage tracking to comply with EU GDPR 2018

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -795,10 +795,13 @@ module Calabash module Android
 
         start_application(options[:intent])
 
-        # What is Calabash tracking? Read this post for information
-        # No private data (like ip addresses) are collected
+        # What was Calabash tracking? Read this post for information
+        # No private data (like ip addresses) were collected
         # https://github.com/calabash/calabash-android/issues/655
-        Calabash::Android::UsageTracker.new.post_usage_async
+        #
+        # Removing usage tracking to avoid problems with EU General Data
+        # Protection Regulation which takes effect in 2018.
+        # Calabash::Android::UsageTracker.new.post_usage_async
       end
 
       def start_application(intent)


### PR DESCRIPTION
### Motivation

Read more about the EU GDPR here:

* http://www.europarl.europa.eu/pdfs/news/expert/background/20160413BKG22980/20160413BKG22980_en.pdf

Completes:

* Remove usage tracking from Calabash Android [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/12759)

Notes:

The MixPanel account that we used to track usage has been disabled for over a year.  