### PR TITLE
Gem: pin cucumber to < 3.0

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
        "lib/calabash-android/lib/AndroidManifest.xml"]
   end.call
 
-  s.add_dependency( "cucumber" )
+  s.add_dependency( "cucumber", "~> 2.0")
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", "~> 1.1" )


### PR DESCRIPTION
### Motivation

Test Cloud is not ready for Cucumber 3.0

Completes:

* Calabash Android: pin cucumber to 2.x [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/29371)
