### PR TITLE
Gem: update version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+### 0.9.1
+
+* Gem: pin cucumber to < 3.0 #847
+* Remove usage tracking to comply with EU GDPR 2018 #835
+* Add check for installed app before attempting uninstall #833
+* Fixed: error when repeated calling funciton send\_tcp() #821
+* fix order of default\_timeout initialization and usage in wait\_for method #818
+* Removing done from operations to fix #722 #812
+* irbrc should capture all errors: otherwise, irb silently eats them. #810
+* Fix: permissions not granted on app update #808
+* Escape string methods for TextHelpers module #807
+* Expand paths when detecting Android SDK #799
+
+#### Server Changes
+
+* Views without id should not generate log messages [#46](https://github.com/calabash/calabash-android-server/pull/46)
+* Travis: ensure ant is installed [#45](https://github.com/calabash/calabash-android-server/pull/45)
+* Fix exceptions when app is running with different locale than english [#44](https://github.com/calabash/calabash-android-server/pull/44)
+* Fix null pointer exception in getViews method [#40](https://github.com/calabash/calabash-android-server/pull/40)

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,5 +1,5 @@
 module Calabash
   module Android
-    VERSION = "0.9.1.pre2"
+    VERSION = "0.9.1"
   end
 end


### PR DESCRIPTION
### 0.9.1

* Gem: pin cucumber to < 3.0 #847
* Remove usage tracking to comply with EU GDPR 2018 #835
* Add check for installed app before attempting uninstall #833
* Fixed: error when repeated calling funciton send\_tcp() #821
* fix order of default\_timeout initialization and usage in wait\_for method #818
* Removing done from operations to fix #722 #812
* irbrc should capture all errors: otherwise, irb silently eats them. #810
* Fix: permissions not granted on app update #808
* Escape string methods for TextHelpers module #807
* Expand paths when detecting Android SDK #799

#### Server Changes

* Views without id should not generate log messages [#46](https://github.com/calabash/calabash-android-server/pull/46)
* Travis: ensure ant is installed [#45](https://github.com/calabash/calabash-android-server/pull/45)
* Fix exceptions when app is running with different locale than english [#44](https://github.com/calabash/calabash-android-server/pull/44)
* Fix null pointer exception in getViews method [#40](https://github.com/calabash/calabash-android-server/pull/40)