### PR TITLE
Gem: do not munge the load path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,8 @@ os:
   - linux
   - osx
 
-# rvm ships with a version of gem and bundler that is too old.
-before_install:
-  - gem update --system
-  - gem --version
-  - gem uninstall -Vax --force --no-abort-on-dependent bundler
-  - gem install bundler --version 1.12.5
-  - bundler --version
-
-# rvm does not support any ruby 2.3 as of Jun 11 2016
 rvm:
-  - 2.1.5
-  - 2.2.5
+  - 2.3.1
 
 env:
   - CI_NO_ANDROID_RUNTIME=1
@@ -29,9 +19,7 @@ script:
 notifications:
   email:
     recipients:
-      - joshua.moody@xamarin.com
-      - chris.fuentes@xamarin.com
-      - tobias.roikjer@xamarin.com
+      - josmoo@microsoft.com
     on_success: change
     on_failure: always
   slack:

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -1,10 +1,21 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "calabash-android/version"
 
 Gem::Specification.new do |s|
   s.name        = "calabash-android"
-  s.version     = Calabash::Android::VERSION
+  s.version     = begin
+    file = "#{File.expand_path(File.join(File.dirname(__FILE__),
+                                      "lib", "calabash-android", "version.rb"))}"
+    m = Module.new
+    m.module_eval IO.read(file).force_encoding("utf-8")
+    version = m::Calabash::Android::VERSION
+    unless /(\d+\.\d+\.\d+(\.pre\d+)?)/.match(version)
+      raise %Q{
+Could not parse constant Calabash::Android::VERSION: '#{version}'
+into a valid version, e.g. 1.2.3 or 1.2.3.pre10
+}
+    end
+    version
+  end
   s.platform    = Gem::Platform::RUBY
   s.license     = "EPL-1.0"
   s.authors     = ["Jonas Maturana Larsen"]


### PR DESCRIPTION
### Motivation

Progress on:

* Calabash: pin ruby clients to cucumber 2.x [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/29369)

When running `rake build` and after updating the `Calabash::Android::VERSION` to "0.9.1", I discovered that the packaged gem was versioned `0.9.1.pre2`.  This is because the active calabash-android gem was 0.9.1.pre2.

We have used the technique in the run-loop and Calabash 2.0 gemspecs for several years.