### PR TITLE
Release/0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 0.9.2
+
+The test server bundled with this gem has the following properties:
+
+```shell
+targetSdkLevel="22"
+ minSdkVersion="8"
+```
+
+* Gem: do not munge the load path #850
+
+#### Server Changes
+
+* Align targetSdkVersion in manifests and build script [#50](https://github.com/calabash/calabash-android-server/pull/50)
+
 ### 0.9.1
 
 * Gem: pin cucumber to < 3.0 #847

--- a/ruby-gem/Rakefile
+++ b/ruby-gem/Rakefile
@@ -9,37 +9,25 @@ class Env
 end
 
 def build
-  test_server_template_dir = find_server_repo_or_raise
+  test_server_dir = find_server_repo_or_raise
 
-  Dir.mktmpdir do |workspace_dir|
-    @test_server_dir = File.join(workspace_dir, 'calabash-android-server', 'server')
-    FileUtils.cp_r(test_server_template_dir, workspace_dir)
+  Dir.chdir(test_server_dir) do
+    system("bin/build.sh")
+    STDOUT.sync = true
 
-    args = [
-      Env.ant_path,
-      "clean",
-      "package",
-      "-debug",
-      "-Dtools.dir=\"#{Env.tools_dir}\"",
-      "-Dandroid.api.level=19",
-      "-Dversion=#{Calabash::Android::VERSION}",
-    ]
-    Dir.chdir(@test_server_dir) do
-      STDOUT.sync = true
-      IO.popen(args.join(" ")) do |io|
-        io.each { |s| print s }
-      end
-      if $?.exitstatus != 0
-        puts "Could not build the test server. Please see the output above."
-        exit $?.exitstatus
-      end
+    if $?.exitstatus != 0
+      puts "Could not build the test server. Please see the output above."
+      exit $?.exitstatus
     end
-
-    FileUtils.mkdir_p "test_servers" unless File.exist? "test_servers"
-
-    FileUtils.cp(File.join(@test_server_dir, "bin", "Test_unsigned.apk"), File.join(File.dirname(__FILE__), 'lib/calabash-android/lib/TestServer.apk'))
-    FileUtils.cp(File.join(@test_server_dir, "AndroidManifest.xml"), File.join(File.dirname(__FILE__), 'lib/calabash-android/lib/AndroidManifest.xml'))
   end
+
+  FileUtils.rm_rf "test_servers"
+  FileUtils.mkdir_p "test_servers"
+
+  FileUtils.cp(File.join(test_server_dir, "server", "bin", "Test_unsigned.apk"),
+               File.join(File.dirname(__FILE__),  'lib/calabash-android/lib/TestServer.apk'))
+  FileUtils.cp(File.join(test_server_dir, "server", "AndroidManifest.xml"),
+               File.join(File.dirname(__FILE__), 'lib/calabash-android/lib/AndroidManifest.xml'))
 end
 
 task :build do

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,5 +1,5 @@
 module Calabash
   module Android
-    VERSION = "0.9.1"
+    VERSION = "0.9.2"
   end
 end


### PR DESCRIPTION
### 0.9.2

The test server bundled with this gem has the following properties:

```shell
targetSdkLevel="22"
 minSdkVersion="8"
   build-tools=26.0.2
```

* Gem: do not munge the load path #850

#### Server Changes

* Align targetSdkVersion in manifests and build script [#50](https://github.com/calabash/calabash-android-server/pull/50)

### 0.9.1

* Gem: pin cucumber to < 3.0 #847
* Remove usage tracking to comply with EU GDPR 2018 #835
* Add check for installed app before attempting uninstall #833
* Fixed: error when repeated calling funciton send\_tcp() #821
* fix order of default\_timeout initialization and usage in wait\_for method #818
* Removing done from operations to fix #722 #812
* irbrc should capture all errors: otherwise, irb silently eats them. #810
* Fix: permissions not granted on app update #808
* Escape string methods for TextHelpers module #807
* Expand paths when detecting Android SDK #799

#### Server Changes

* Views without id should not generate log messages [#46](https://github.com/calabash/calabash-android-server/pull/46)
* Travis: ensure ant is installed [#45](https://github.com/calabash/calabash-android-server/pull/45)
* Fix exceptions when app is running with different locale than english [#44](https://github.com/calabash/calabash-android-server/pull/44)
* Fix null pointer exception in getViews method [#40](https://github.com/calabash/calabash-android-server/pull/40)
