### PR TITLE
Update rubyzip and yard dependencies in response to security alerts

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -43,7 +43,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( "cucumber", "~> 2.0")
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", "~> 1.1" )
+  s.add_dependency( "rubyzip", ">= 1.2.1" )
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.7.1', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -50,7 +50,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( 'luffa' )
 
   s.add_development_dependency( 'rake', '~> 10.3' )
-  s.add_development_dependency( 'yard', '~> 0.8' )
+  s.add_development_dependency( 'yard', '>= 0.9.12', '< 1.0' )
   puts RUBY_PLATFORM
   if RUBY_PLATFORM[/darwin/] || RUBY_PLATFORM["linux"]
     s.add_development_dependency( 'redcarpet', '~> 3.1' )


### PR DESCRIPTION
### Motivation

Completes:

* Calabash Android:  rubyzip version has a security vulnerability [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/30194)

I am confident that this will not be disruptive to Test Cloud or locally because my local Gemfile.lock is already pinned to 1.2.1.