### PR TITLE
Allow test APKs to be installed

### DIFF
--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -362,9 +362,9 @@ module Calabash module Android
 
       def install_app(app_path)
         if _sdk_version >= 23
-          cmd = "#{adb_command} install -g \"#{app_path}\""
+          cmd = "#{adb_command} install -g -t \"#{app_path}\""
         else
-          cmd = "#{adb_command} install \"#{app_path}\""
+          cmd = "#{adb_command} install -t \"#{app_path}\""
         end
 
         log "Installing: #{app_path}"


### PR DESCRIPTION
apk built using android studio are not getting installed. Gradle generates a test APK when you have only run or debugged your app or have used the Android Studio
https://developer.android.com/studio/command-line/adb.html#-t-option