### PR TITLE
Release/0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.9.3
+
+Added support for Android P (api 28) devices.
+
+* Changed build process for server: added gradle build instead of ant.
+* Removed the use of blacklisted api for latest android versions.
+* Clean-up android server from external libs.
+
 ### 0.9.2
 
 The test server bundled with this gem has the following properties:

--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ Calabash Android requires ruby >= 2.0 (latest stable release is preferred).
 #### Ruby on MacOS
 
 On MacOS, we recommend using a managed Ruby like
-[rbenv](https://github.com/sstephenson/rbenv) or [rvm](https://rvm.io/)).  If
-you are just getting started or don't want to commit to a managed Ruby, you
-should install and use the [Calabash Sandbox](https://github.com/calabash/install).
-
-```
-# Installs the Calabash Sandbox
-$ curl -sSL https://raw.githubusercontent.com/calabash/install/master/install-osx.sh | bash
-```
+[rbenv](https://github.com/sstephenson/rbenv) or [rvm](https://rvm.io/)).
 
 Please do **not** install gems with `sudo`
 

--- a/ruby-gem/Rakefile
+++ b/ruby-gem/Rakefile
@@ -9,24 +9,26 @@ class Env
 end
 
 def build
-  test_server_dir = find_server_repo_or_raise
+  test_server_dir = File.join(find_server_repo_or_raise, "server")
 
   Dir.chdir(test_server_dir) do
-    system("bin/build.sh")
+    system('BUILDOUTPUT="$(./gradlew clean assembleAndroidTest -q)"')
     STDOUT.sync = true
 
     if $?.exitstatus != 0
       puts "Could not build the test server. Please see the output above."
       exit $?.exitstatus
+    else
+      puts "Calabash Android Server was built successfully."
     end
   end
 
   FileUtils.rm_rf "test_servers"
   FileUtils.mkdir_p "test_servers"
 
-  FileUtils.cp(File.join(test_server_dir, "server", "bin", "Test_unsigned.apk"),
+  FileUtils.cp(File.join(test_server_dir, "app", "build", "outputs", "apk", "androidTest", "debug", "TestServer.apk"),
                File.join(File.dirname(__FILE__),  'lib/calabash-android/lib/TestServer.apk'))
-  FileUtils.cp(File.join(test_server_dir, "server", "AndroidManifest.xml"),
+  FileUtils.cp(File.join(test_server_dir, "AndroidManifest.xml"),
                File.join(File.dirname(__FILE__), 'lib/calabash-android/lib/AndroidManifest.xml'))
 end
 

--- a/ruby-gem/api/Gemfile
+++ b/ruby-gem/api/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 
-gem 'json', '1.8.2'
-gem 'xamarin-test-cloud', '2.0.0.pre5'
+gem 'json', '~> 1.8'
+gem 'xamarin-test-cloud', '~> 2.0'
 gem 'cucumber', '~> 2.0.0'
-#gem 'calabash-android', '<version>'
 gem 'calabash-android', path: '../'

--- a/ruby-gem/api/Gemfile.lock
+++ b/ruby-gem/api/Gemfile.lock
@@ -1,18 +1,21 @@
+PATH
+  remote: ..
+  specs:
+    calabash-android (0.9.3)
+      awesome_print (~> 1.2)
+      cucumber (~> 2.0)
+      escape (~> 0.0.4)
+      httpclient (>= 2.7.1, < 3.0)
+      json (~> 1.8)
+      luffa
+      rubyzip (>= 1.2.1)
+      slowhandcuke (~> 0.0.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    awesome_print (1.7.0)
-    builder (3.2.2)
-    calabash-android (0.7.4.pre1)
-      awesome_print (~> 1.2)
-      cucumber
-      escape (~> 0.0.4)
-      httpclient (>= 2.3.2, < 3.0)
-      json (~> 1.8)
-      luffa
-      retriable (>= 1.3.3.1, < 1.5)
-      rubyzip (~> 1.1)
-      slowhandcuke (~> 0.0.3)
+    awesome_print (1.8.0)
+    builder (3.2.3)
     cucumber (2.0.2)
       builder (>= 2.1.2)
       cucumber-core (~> 1.2.0)
@@ -22,28 +25,28 @@ GEM
       multi_test (>= 0.1.2)
     cucumber-core (1.2.0)
       gherkin (~> 2.12.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     escape (0.0.4)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    httpclient (2.8.0)
-    json (1.8.2)
+    httpclient (2.8.3)
+    json (1.8.6)
     luffa (2.0.0)
       awesome_print (~> 1.2)
       json (~> 1.8)
       retriable (>= 1.3.3.1, < 2.1)
       thor (~> 0.19)
-    mime-types (2.99.2)
-    multi_json (1.12.1)
+    mime-types (2.99.3)
+    multi_json (1.13.1)
     multi_test (0.1.2)
-    retriable (1.4.1)
-    rubyzip (1.2.0)
+    retriable (2.0.2)
+    rubyzip (1.2.1)
     slowhandcuke (0.0.3)
       cucumber
-    thor (0.19.1)
-    xamarin-test-cloud (2.0.0.pre5)
+    thor (0.20.0)
+    xamarin-test-cloud (2.1.2)
       bundler (>= 1.3.0, < 2.0)
-      httpclient (~> 2.6)
+      httpclient (>= 2.7.1, < 3.0)
       json (~> 1.8)
       mime-types (~> 2.99)
       retriable (>= 1.3.3.1, < 2.1)
@@ -54,10 +57,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  calabash-android (= 0.7.4.pre1)
+  calabash-android!
   cucumber (~> 2.0.0)
-  json (= 1.8.2)
-  xamarin-test-cloud (= 2.0.0.pre5)
+  json (~> 1.8)
+  xamarin-test-cloud (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.16.2

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,5 +1,5 @@
 module Calabash
   module Android
-    VERSION = "0.9.2"
+    VERSION = "0.9.3"
   end
 end


### PR DESCRIPTION
### 0.9.3

Added support for Android P (api 28) devices.

* Changed build process for server: added gradle build instead of ant.
* Removed the use of blacklisted api for latest android versions.
* Clean-up android server from external libs.

---
**PR for android server:** https://github.com/calabash/calabash-android-server/pull/67

Changed inside server:
* Fixed deprecated target api popup issue on Android P #66
* Make the server compile with the android gradle plugin #65
* ###version### not replaced in server #64
* Implemented logic to handle webview input #63 
* Removed deprecated API from android server #61
* remove make complete (dark gray list) #60
* Added jenkins 2.0 blue ocean pipeline #59
* Fixed calabash android server on Android <= 3. #58 
* Migrate build to gradle.#57
* Fixes for integration tests. #56
* Changed build.sh to prevent silent build failings. #55
* Feature/use less reflection #54
* Fix for resource 0xffff... missing error #53
* Integration tests should run in CI #52
