### PR TITLE
Support  latest Cucumber versions

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -40,7 +40,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
        "lib/calabash-android/lib/AndroidManifest.xml"]
   end.call
 
-  s.add_dependency( "cucumber", "~> 3.0")
+  s.add_dependency( 'cucumber' )
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", ">= 1.2.1" )

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -40,7 +40,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
        "lib/calabash-android/lib/AndroidManifest.xml"]
   end.call
 
-  s.add_dependency( "cucumber", "~> 2.0")
+  s.add_dependency( "cucumber", "~> 3.0")
   s.add_dependency( "json", '~> 1.8' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", ">= 1.2.1" )


### PR DESCRIPTION
The gem is pinned to Cucumber <3.0 and there are new versions available. The PR change the maximum version to <3.99.

So far we see some advantages in newest Cucumber version and it would be nice to be able to use them. After bumping Cucumber locally I didn't see any issues with latest Cucumber (running ~400 tests).