### PR TITLE
Do not bind Calabash to any versions of json

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -43,7 +43,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( 'json' )
   s.add_dependency( 'cucumber' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", ">= 1.2.1" )
+  s.add_dependency( "rubyzip", "~> 1.2" )
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.7.1', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -41,7 +41,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   end.call
 
   s.add_dependency( "cucumber", "~> 2.0")
-  s.add_dependency( "json", '~> 1.8' )
+  s.add_dependency( 'json' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
   s.add_dependency( "rubyzip", ">= 1.2.1" )
   s.add_dependency( "awesome_print", '~> 1.2')


### PR DESCRIPTION
The version is quite outdated, in this way users are able to decide which version they want to use.