### PR TITLE
Release/0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
+### 0.9.9
+
+Users can update to ruby 2.6 and use whatever version bundler they would
+like.
+
+* gem: remove luffa dependency; add Version class #907
+* Fixed typos in README.md #906
+* Fixing META-INF regex #902
+* Allow test APKs to be installed #865
+
+#### Test Server 0.9.9
+
+* Feature/fix activity monitor race #84
+
 ### 0.9.8
 
 No behavior changes in TestServer.apk.
 
-This release allows Calabash Android to used with json 2.0
+This release allows Calabash Android to be used with json 2.0
 and cucumber 3.0.  This will also allow users to update
 their ruby to 2.5.x.
 

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -44,7 +44,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( 'json' )
   s.add_dependency( 'cucumber' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", "~> 1.2" )
+  s.add_dependency( "rubyzip", ">= 1.2", "< 1.3")
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.7.1', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.8"
+    VERSION = "0.9.9"
 
     # A model of a software release version that can be used to compare two versions.
     #


### PR DESCRIPTION
### 0.9.9

Users can update to ruby 2.6 and use whatever version bundler they would like.

* gem: remove luffa dependency; add Version class #907
* Fixed typos in README.md #906
* Fixing META-INF regex #902
* Allow test APKs to be installed #865

#### Test Server 0.9.9

* Feature/fix activity monitor race #84