### PR TITLE
Rename Calabash.keychain to TestCloudDev.keychain

### DIFF
--- a/ruby-gem/lib/calabash-android/dot_dir.rb
+++ b/ruby-gem/lib/calabash-android/dot_dir.rb
@@ -1,10 +1,10 @@
 module Calabash
   module Android
-    # A module for managing the ~/.calabash directory.
+    # A module for managing the ~/.test-cloud-dev directory.
     module DotDir
       def self.directory
         home = Calabash::Android::Environment.user_home_directory
-        dir = File.join(home, ".calabash")
+        dir = File.join(home, ".test-cloud-dev")
         if !File.exist?(dir)
           FileUtils.mkdir_p(dir)
         end

--- a/ruby-gem/lib/calabash-android/store/preferences.rb
+++ b/ruby-gem/lib/calabash-android/store/preferences.rb
@@ -8,7 +8,7 @@ module Calabash
 
     # Users preferences persisted across runs:
     #
-    # ~/.calabash/preferences/preferences.json
+    # ~/.test-cloud-dev/preferences/preferences.json
     class Preferences
       def initialize
         dot_dir = Calabash::Android::DotDir.directory

--- a/ruby-gem/spec/lib/dot_dir_spec.rb
+++ b/ruby-gem/spec/lib/dot_dir_spec.rb
@@ -1,7 +1,7 @@
 describe Calabash::Android::DotDir do
 
   let(:home_dir) { "./tmp/dot-calabash-examples" }
-  let(:dot_dir) { File.join(home_dir, ".calabash") }
+  let(:dot_dir) { File.join(home_dir, ".test-cloud-dev") }
 
   before do
     allow(Calabash::Android::Environment).to receive(:user_home_directory).and_return home_dir


### PR DESCRIPTION
[User Story 63322: rename calabash-codesign and Calabash.key to TestCloudDev.keychain](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63322)