### PR TITLE
Fix signing for newer keytool

### DIFF
--- a/ruby-gem/lib/calabash-android/java_keystore.rb
+++ b/ruby-gem/lib/calabash-android/java_keystore.rb
@@ -51,6 +51,10 @@ class JavaKeystore
 
     # E.g. MD5withRSA or MD5withRSAandMGF1
     encryption = signature_algorithm_name.split('with')[1].split('and')[0]
+
+    # keytool with newer java versions has "Signature algorithm name: SHA1withRSA (weak)"
+    encryption.gsub!(' (weak)', '')
+
     signing_algorithm = "SHA1with#{encryption}"
     digest_algorithm = 'SHA1'
 


### PR DESCRIPTION
With new jdk, the keytool reports 
`Signature algorithm name: SHA1withRSA (weak)`

as compared to old jdk which used to report it as:
`Signature algorithm name: SHA1withRSA`

This breaks the parsing and results in failing of apk resigning. This PR tries to fix that