### PR TITLE
Update .travis.yml to run ruby 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 
 os:
   - linux
-  - osx
 
 rvm:
   - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ sudo: false
 
 os:
   - linux
+  - osx
 
 rvm:
-  - 2.3.1
+  - 2.7.1
 
 env:
   - CI_NO_ANDROID_RUNTIME=1


### PR DESCRIPTION
The ci running in osx is failing due to some system issue. This is preventing PRs from being merged.
Until someone with better knowledge or access to address this, we can disable the execution in osx.