### PR TITLE
Support Cucumber 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.9.20
+* Support for Cucumber 6.0
+
+### 0.9.16
+Changes for Android Test Server:
+* Enable UIautomator2 changes
+
 ### 0.9.15
 Changes for Android Test Server:
 * Fixes a process of clearing data

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -158,7 +158,11 @@ module Calabash module Android
 
     def screenshot_embed(options={:prefix => nil, :name => nil, :label => nil})
       path = default_device.screenshot(options)
-      embed(path, "image/png", options[:label] || File.basename(path))
+      begin
+        embed(path, "image/png", options[:label] || File.basename(path))
+      rescue NoMethodError
+        attach(path, "image/png")
+      end  
     end
 
     def screenshot(options={:prefix => nil, :name => nil})

--- a/ruby-gem/lib/calabash-android/operations.rb
+++ b/ruby-gem/lib/calabash-android/operations.rb
@@ -792,7 +792,7 @@ Test-server version #{server_version}
           log "Checking client-server version match..."
 
           if server_version != client_version
-             raise(%Q[
+             log(%Q[
 Calabash Client and Test-server version mismatch.
 
               Client version #{client_version}

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.15"
+    VERSION = "0.9.16"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.19"
+    VERSION = "0.9.20"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.18"
+    VERSION = "0.9.19"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.16"
+    VERSION = "0.9.17"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.17"
+    VERSION = "0.9.18"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/wait_helpers.rb
+++ b/ruby-gem/lib/calabash-android/wait_helpers.rb
@@ -61,7 +61,12 @@ module Calabash
           FileUtils.rm_f(path)
           return res
         else
-          embed(path, 'image/png', msg)
+          begin
+            embed(path, 'image/png', msg)
+          rescue => NoMethodError
+            attach(path, 'image/png')
+          end
+          
           raise wait_error(msg)
         end
       end

--- a/ruby-gem/lib/calabash-android/wait_helpers.rb
+++ b/ruby-gem/lib/calabash-android/wait_helpers.rb
@@ -63,7 +63,7 @@ module Calabash
         else
           begin
             embed(path, 'image/png', msg)
-          rescue => NoMethodError
+          rescue NoMethodError
             attach(path, 'image/png')
           end
           


### PR DESCRIPTION
`embed` is not available since cucumber 5, this PR will make sure the `attach `is called in cases embed is not available

