### PR TITLE
Downgrade rubyzip

### DIFF
--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -44,7 +44,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( 'json' )
   s.add_dependency( 'cucumber' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", ">= 1.2.2", "< 1.3")
+  s.add_dependency( "rubyzip", "1.2.1")
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.7.1', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')

--- a/ruby-gem/calabash-android.gemspec
+++ b/ruby-gem/calabash-android.gemspec
@@ -44,7 +44,7 @@ into a valid version, e.g. 1.2.3 or 1.2.3.pre10
   s.add_dependency( 'json' )
   s.add_dependency( 'cucumber' )
   s.add_dependency( "slowhandcuke", '~> 0.0.3')
-  s.add_dependency( "rubyzip", "1.3.0")
+  s.add_dependency( "rubyzip", ">= 1.2.2", "< 1.3")
   s.add_dependency( "awesome_print", '~> 1.2')
   s.add_dependency( 'httpclient', '>= 2.7.1', '< 3.0')
   s.add_dependency( 'escape', '~> 0.0.4')

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.23"
+    VERSION = "0.9.24"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.22"
+    VERSION = "0.9.23"
 
     # A model of a software release version that can be used to compare two versions.
     #

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Android
-    VERSION = "0.9.21"
+    VERSION = "0.9.22"
 
     # A model of a software release version that can be used to compare two versions.
     #


### PR DESCRIPTION
the versions that are >= 1.3.1 have an incompatible check which seems to affect running Calabash on Windows. Since I cannot really reproduce the problem on my mac, the only reasonable solution would be to revert the part of @igorFedotenkov PR