### PR TITLE
Do not overwrite Cucumber log method

### DIFF
--- a/ruby-gem/bin/calabash-android-build.rb
+++ b/ruby-gem/bin/calabash-android-build.rb
@@ -1,6 +1,6 @@
 def calabash_build(app)
   apk_fingerprint = fingerprint_from_apk(app)
-  log "#{app} was signed with a certificate with fingerprint #{apk_fingerprint}"
+  calabash_log "#{app} was signed with a certificate with fingerprint #{apk_fingerprint}"
 
   keystores = JavaKeystore.get_keystores
   if keystores.empty?
@@ -72,7 +72,7 @@ def calabash_build(app)
     begin
 
     rescue => e
-      log e
+      calabash_log e
       raise "Could not sign test server"
     end
   end

--- a/ruby-gem/bin/calabash-android-run.rb
+++ b/ruby-gem/bin/calabash-android-run.rb
@@ -29,7 +29,7 @@ def calabash_run(app_path = nil)
   STDOUT.sync = true
   arguments = ARGV - ["--no-build"]
   cmd = "\"#{RbConfig.ruby}\" -S cucumber #{arguments.join(" ")} #{env}"
-  log cmd
+  calabash_log cmd
   exit_code = system(cmd)
 
   sleep(1)

--- a/ruby-gem/features-skeleton/support/app_installation_hooks.rb
+++ b/ruby-gem/features-skeleton/support/app_installation_hooks.rb
@@ -10,9 +10,9 @@ Before do |scenario|
   feature = scenario.feature
   if FeatureMemory.feature != feature || ENV['RESET_BETWEEN_SCENARIOS'] == '1'
     if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
-      log 'New scenario - reinstalling apps'
+      calabash_log 'New scenario - reinstalling apps'
     else
-      log 'First scenario in feature - reinstalling apps'
+      calabash_log 'First scenario in feature - reinstalling apps'
     end
 
     ensure_app_installed

--- a/ruby-gem/integration-tests/features/support/app_installation_hooks.rb
+++ b/ruby-gem/integration-tests/features/support/app_installation_hooks.rb
@@ -10,9 +10,9 @@ Before do |scenario|
   feature = scenario.feature
   if FeatureMemory.feature != feature || ENV['RESET_BETWEEN_SCENARIOS'] == '1'
     if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
-      log 'New scenario - reinstalling apps'
+      calabash_log 'New scenario - reinstalling apps'
     else
-      log 'First scenario in feature - reinstalling apps'
+      calabash_log 'First scenario in feature - reinstalling apps'
     end
 
     uninstall_apps

--- a/ruby-gem/lib/calabash-android/drag_helpers.rb
+++ b/ruby-gem/lib/calabash-android/drag_helpers.rb
@@ -8,7 +8,7 @@ module Calabash
       include Calabash::Android::MonkeyHelpers
 
       def drag_coordinates(from_x, from_y, to_x, to_y, steps=10, hold_time=0.5, hang_time=0.5)
-        log "Dragging from #{from_x},#{from_y} to #{to_x},#{to_y}"
+        calabash_log "Dragging from #{from_x},#{from_y} to #{to_x},#{to_y}"
         monkey_move_from(from_x, from_y,
                          to_x, to_y,
                          hold_time: hold_time,

--- a/ruby-gem/lib/calabash-android/env.rb
+++ b/ruby-gem/lib/calabash-android/env.rb
@@ -10,7 +10,7 @@ class Env
 
   def self.exit_unless_android_sdk_is_available
     if android_home_path
-      log "Android SDK found at: #{android_home_path}"
+      calabash_log "Android SDK found at: #{android_home_path}"
       return
     end
     puts "Could not find an Android SDK please make sure it is installed."
@@ -27,8 +27,8 @@ class Env
   def self.exit_unless_jdk_is_available
     jdk = jdk_path
     if find_executable_on_path(keytool_executable) || jdk
-      log "JDK found on PATH." if find_executable_on_path(keytool_executable)
-      log "JDK found at: #{jdk}" if jdk
+      calabash_log "JDK found on PATH." if find_executable_on_path(keytool_executable)
+      calabash_log "JDK found at: #{jdk}" if jdk
       return
     end
     puts "Could not find Java Development Kit please make sure it is installed."
@@ -84,7 +84,7 @@ class Env
     zipalign_path = File.join(android_home_path, 'tools', zipalign_executable)
 
     unless File.exists?(zipalign_path)
-      log "Did not find zipalign at '#{zipalign_path}'. Trying to find zipalign in tools directories."
+      calabash_log "Did not find zipalign at '#{zipalign_path}'. Trying to find zipalign in tools directories."
 
       tools_directories.each do |dir|
         zipalign_path = File.join(dir, zipalign_executable)
@@ -93,10 +93,10 @@ class Env
     end
 
     if File.exists?(zipalign_path)
-      log "Found zipalign at '#{zipalign_path}'"
+      calabash_log "Found zipalign at '#{zipalign_path}'"
       zipalign_path
     else
-      log("Did not find zipalign in any of '#{tools_directories.join("','")}'.", true)
+      calabash_log("Did not find zipalign in any of '#{tools_directories.join("','")}'.", true)
       raise 'Could not find zipalign'
     end
   end
@@ -131,7 +131,7 @@ class Env
 
   def self.tools_dir
     tools_dir = tools_directories.first
-    log "Found tools directory at '#{tools_dir}'"
+    calabash_log "Found tools directory at '#{tools_dir}'"
     tools_dir
   end
 


### PR DESCRIPTION
This is mixed with Cucumber, therefore new Cucumber versions where puts is deprecated cannot use `log` method anymore